### PR TITLE
Keerthi/velodyne deskew info

### DIFF
--- a/velodyne_msgs/CMakeLists.txt
+++ b/velodyne_msgs/CMakeLists.txt
@@ -8,6 +8,8 @@ add_message_files(
   FILES
   VelodynePacket.msg
   VelodyneScan.msg
+  VelodyneSweepInfo.msg
+  VelodyneDeskewInfo.msg
 )
 generate_messages(DEPENDENCIES std_msgs)
 

--- a/velodyne_msgs/msg/VelodyneDeskewInfo.msg
+++ b/velodyne_msgs/msg/VelodyneDeskewInfo.msg
@@ -1,4 +1,24 @@
-# Velodyne Deskew Info.
+# Velodyne Deskew Info
 
+# The "seq" and "stamp" fields of the header of this message matches the 
+# same fields of the header in the corresponding "VelodyneScan" message
 Header           header         # standard ROS message header
+
+# Velodyne LIDAR reports 3D points by sweeping laser beams radially from 
+# 0 to 360 degrees azimuth angle. The "sweep_info" field reports an array of 
+# "VelodyneSweepInfo" messages, each containing a pair of ROS timestamp and 
+# angle (in degrees). The angle field "start_angle" indicates the starting 
+# azimuth sweep angle of a particular section of pointcloud and the timestamp 
+# field "stamp" indicates the time when the points in that section of the sweep 
+# were captured.
+# The ending angle for a sweep section should be inferred by the "start_angle" 
+# of the next sweep section which is in the next element of the array.
+# The first sweep section always starts at 0 degrees and the ending angle for 
+# the last sweep section should always be assumed by the subscriber to be 360 
+# degrees.
+
+# Angle 0 corresponds to the positive Y direction of Velodyne's local 
+# co-ordinate frame. Refer the Velodyne user manual for coordinate system 
+# definition.
+
 VelodyneSweepInfo[] sweep_info  # vector of sweep angle and timing info

--- a/velodyne_msgs/msg/VelodyneDeskewInfo.msg
+++ b/velodyne_msgs/msg/VelodyneDeskewInfo.msg
@@ -1,0 +1,4 @@
+# Velodyne Deskew Info.
+
+Header           header         # standard ROS message header
+VelodyneSweepInfo[] sweep_info  # vector of sweep angle and timing info

--- a/velodyne_msgs/msg/VelodyneSweepInfo.msg
+++ b/velodyne_msgs/msg/VelodyneSweepInfo.msg
@@ -1,0 +1,4 @@
+# Velodyne LIDAR Sweep Angle and Timestamp info.
+
+time stamp              # packet timestamp
+float32 start_angle     # start of the sweep

--- a/velodyne_msgs/msg/VelodyneSweepInfo.msg
+++ b/velodyne_msgs/msg/VelodyneSweepInfo.msg
@@ -1,4 +1,14 @@
 # Velodyne LIDAR Sweep Angle and Timestamp info.
 
+# Velodyne LIDAR reports 3D points by sweeping laser beams radially from 
+# 0 to 360 degrees azimuth angle. The angle field "start_angle" indicates the starting 
+# azimuth sweep angle of a particular section of pointcloud and the timestamp field 
+# "stamp" indicates the time when the points in that section of the sweep were 
+# captured.
+
+# Angle 0 corresponds to the positive Y direction of Velodyne's local 
+# co-ordinate frame. Refer the Velodyne user manual for coordinate system 
+# definition.
+
 time stamp              # packet timestamp
 float32 start_angle     # start of the sweep

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -30,11 +30,11 @@ namespace velodyne_pointcloud
 
     // advertise output point cloud (before subscribing to input data)
     output_pointcloud_ =
-      node.advertise<sensor_msgs::PointCloud2>("velodyne_points", 10);
+      node.advertise<sensor_msgs::PointCloud2>("velodyne_points", 2);
     
     // advertise output deskew info
     output_deskew_info_ =
-      node.advertise<velodyne_msgs::VelodyneDeskewInfo>("velodyne_deskew_info", 10);
+      node.advertise<velodyne_msgs::VelodyneDeskewInfo>("velodyne_deskew_info", 2);
         
     srv_ = boost::make_shared <dynamic_reconfigure::Server<velodyne_pointcloud::
       CloudNodeConfig> > (private_nh);
@@ -48,7 +48,7 @@ namespace velodyne_pointcloud
     
     // subscribe to VelodyneScan packets
     velodyne_scan_ =
-      node.subscribe("velodyne_packets", 10,
+      node.subscribe("velodyne_packets", 2,
                      &Convert::processScan, (Convert *) this,
                      ros::TransportHints().tcpNoDelay(true));
   }

--- a/velodyne_pointcloud/src/conversions/convert.h
+++ b/velodyne_pointcloud/src/conversions/convert.h
@@ -25,6 +25,9 @@
 #include <dynamic_reconfigure/server.h>
 #include <velodyne_pointcloud/CloudNodeConfig.h>
 
+#include <velodyne_msgs/VelodyneSweepInfo.h>
+#include <velodyne_msgs/VelodyneDeskewInfo.h>
+
 namespace velodyne_pointcloud
 {
   class Convert
@@ -38,6 +41,7 @@ namespace velodyne_pointcloud
     
     void callback(velodyne_pointcloud::CloudNodeConfig &config,
                 uint32_t level);
+    velodyne_msgs::VelodyneSweepInfo create_sweep_entry(ros::Time stamp, float angle);
     void processScan(const velodyne_msgs::VelodyneScan::ConstPtr &scanMsg);
 
     ///Pointer to dynamic reconfigure service srv_
@@ -46,11 +50,13 @@ namespace velodyne_pointcloud
     
     boost::shared_ptr<velodyne_rawdata::RawData> data_;
     ros::Subscriber velodyne_scan_;
-    ros::Publisher output_;
+    ros::Publisher output_pointcloud_, output_deskew_info_;
 
     //make the pointcloud container a member variable to append different slices
     velodyne_rawdata::VPointCloud accumulated_cloud_;
+    velodyne_msgs::VelodyneDeskewInfo deskew_info_;
     float prev_azimuth_;
+    ros::Time prev_stamp_;
     /// configuration parameters
     typedef struct {
       int npackets;                    ///< number of packets to combine

--- a/velodyne_pointcloud/src/conversions/convert.h
+++ b/velodyne_pointcloud/src/conversions/convert.h
@@ -50,7 +50,7 @@ namespace velodyne_pointcloud
 
     //make the pointcloud container a member variable to append different slices
     velodyne_rawdata::VPointCloud accumulated_cloud_;
-    float section_angle_;
+    float prev_azimuth_;
     /// configuration parameters
     typedef struct {
       int npackets;                    ///< number of packets to combine


### PR DESCRIPTION
This PR updates velodyne LIDAR driver with following changes:
1. Fixes the bug which was causing point cloud publisher to publish more than 360 degree sweep every time - causing the publishing rate to be around 9Hz. With this fix, we now precisely publish one full 360 degree sweep in every pointcloud message and at 10 Hz.
2. Publishes new topic `velodyne_deskew_info` at the same rate (10 Hz) as the pointcloud. This new message contains [stamp, start_angle] pairs which will help us deskew the lidar points at detection or fusion layer. For example, if we consider two consecutive pairs of [stamp, start_angle], the points swept between `start_angle1` and `start_angle2` are captured at `stamp1`. First pair in every message will always have `start_angle` as 0.0 degrees and the last pair's `stamp` is valid until 360 degrees. The headers of `velodyne_deskew_info` and it's corresponding `velodyne_points` message will match.

Angle 0 corresponds to the positive Y direction of Velodyne's local co-ordinate frame. Refer the Velodyne user manual for coordinate system definition.

Sample message looks like this:
```
header: 
  seq: 35
  stamp: 
    secs: 1561246311
    nsecs: 190596581
  frame_id: "velodyne_tl"
sweep_info: 
  - 
    stamp: 
      secs: 1561246311
      nsecs:  89745522
    start_angle: 0.0
  - 
    stamp: 
      secs: 1561246311
      nsecs:  90395212
    start_angle: 0.319999992847
  - 
    stamp: 
      secs: 1561246311
      nsecs:  92369795
    start_angle: 2.71000003815
  - 
    stamp: 
      secs: 1561246311
      nsecs:  94049454
    start_angle: 5.11000013351
........
  - 
    stamp: 
      secs: 1561246311
      nsecs: 188600063
    start_angle: 353.829986572
  - 
    stamp: 
      secs: 1561246311
      nsecs: 189273119
    start_angle: 356.230010986
  - 
    stamp: 
      secs: 1561246311
      nsecs: 189931870
    start_angle: 358.619995117
```

Tests Done:
------------------------
1. Ensured that the publish rate of `velodyne_points` topic is exactly 10 Hz instead of 8-9Hz like before. This shows that the bug which was causing us to publish more than 360 degree scans in one message has been fixed. Now we publish exactly 360 degree scan in each message. This is also verified visually by looking at pointcloud in rviz and making sure there are no multiple points for the same moving vehicle in one scan.

2. Ensured that the `velodyne_deskew_info` topic is published with correct timestamp for every sweep angle by making sure the timestamps and angles increase monotonously in a single scan. Also verified that the timestamps of each packet in a scan is lesser (earlier in time) than the timestamp of the overall scan (header timestamp). This difference in timestamps should be used to deskew the points.