### PR TITLE
Erik/duplicate points bugfix

### DIFF
--- a/velodyne_pointcloud/CMakeLists.txt
+++ b/velodyne_pointcloud/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(velodyne_pointcloud)
 
+add_definitions("-std=c++11")
+
 set(${PROJECT_NAME}_CATKIN_DEPS
     angles
     nodelet

--- a/velodyne_pointcloud/CMakeLists.txt
+++ b/velodyne_pointcloud/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(velodyne_pointcloud)
 
-add_definitions("-std=c++11")
-
 set(${PROJECT_NAME}_CATKIN_DEPS
     angles
     nodelet

--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -140,7 +140,7 @@ class RawData
    */
   int setup(ros::NodeHandle private_nh);
 
-  float unpack(const velodyne_msgs::VelodynePacket& pkt, VPointCloud& pc, size_t* valid_pnts=nullptr) const;
+  float unpackAndAdd(const velodyne_msgs::VelodynePacket& pkt, VPointCloud& pc, size_t* valid_pnts=nullptr) const;
 
   void setParameters(double min_range, double max_range, double view_direction, double view_width);
 

--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -21,169 +21,163 @@
 #define __VELODYNE_RAWDATA_H
 
 #include <errno.h>
-#include <stdint.h>
-#include <string>
-#include <boost/format.hpp>
 #include <math.h>
+#include <stdint.h>
+#include <boost/format.hpp>
+#include <string>
 
-#include <ros/ros.h>
 #include <pcl_ros/point_cloud.h>
+#include <ros/ros.h>
 #include <velodyne_msgs/VelodyneScan.h>
-#include <velodyne_pointcloud/point_types.h>
 #include <velodyne_pointcloud/calibration.h>
+#include <velodyne_pointcloud/point_types.h>
 
-namespace velodyne_rawdata
+namespace velodyne_rawdata {
+// Shorthand typedefs for point cloud representations
+typedef velodyne_pointcloud::PointXYZIR VPoint;
+typedef pcl::PointCloud<VPoint> VPointCloud;
+
+/**
+ * Raw Velodyne packet constants and structures.
+ */
+static const int SIZE_BLOCK = 100;
+static const int RAW_SCAN_SIZE = 3;
+static const int SCANS_PER_BLOCK = 32;
+static const int BLOCK_DATA_SIZE = (SCANS_PER_BLOCK * RAW_SCAN_SIZE);
+
+static const float ROTATION_RESOLUTION = 0.01f;    // [deg]
+static const uint16_t ROTATION_MAX_UNITS = 36000u; // [deg/100]
+static const float DISTANCE_RESOLUTION = 0.002f;   // [m]
+
+/** @todo make this work for both big and little-endian machines */
+static const uint16_t UPPER_BANK = 0xeeff;
+static const uint16_t LOWER_BANK = 0xddff;
+
+/** Special defines for VLP support **/
+typedef struct vlp_spec
 {
-  // Shorthand typedefs for point cloud representations
-  typedef velodyne_pointcloud::PointXYZIR VPoint;
-  typedef pcl::PointCloud<VPoint> VPointCloud;
+  int firing_seqs_per_block;
+  int lasers_per_firing_seq;
+  int lasers_per_firing;
+  float firing_duration;     // [us]
+  float firing_seq_duration; // [us]
+  float block_duration;      // [us] = firing_seq_duration * firing_seqs_per_block
+  float distance_resolution; // [us]
+} vlp_spec_t;
+
+static const vlp_spec_t VLP_16_SPEC = { 2, 16, 1, 2.304f, 55.296f, 110.592f, 0.002f };
+
+static const vlp_spec_t VLP_32_SPEC = { 1, 32, 2, 2.304f, 55.296f, 55.296f, 0.004f };
+
+/** \brief Raw Velodyne data block.
+ *
+ *  Each block contains data from either the upper or lower laser
+ *  bank.  The device returns three times as many upper bank blocks.
+ *
+ *  use stdint.h types, so things work with both 64 and 32-bit machines
+ */
+typedef struct raw_block
+{
+  uint16_t header;   ///< UPPER_BANK or LOWER_BANK
+  uint16_t rotation; ///< 0-35999, divide by 100 to get degrees
+  uint8_t data[BLOCK_DATA_SIZE];
+} raw_block_t;
+
+/** used for unpacking the first two data bytes in a block
+ *
+ *  They are packed into the actual data stream misaligned.  I doubt
+ *  this works on big endian machines.
+ */
+union two_bytes
+{
+  uint16_t uint;
+  uint8_t bytes[2];
+};
+
+static const int PACKET_SIZE = 1206;
+static const int BLOCKS_PER_PACKET = 12;
+static const int PACKET_STATUS_SIZE = 4;
+static const int SCANS_PER_PACKET = (SCANS_PER_BLOCK * BLOCKS_PER_PACKET);
+
+/** \brief Raw Velodyne packet.
+ *
+ *  revolution is described in the device manual as incrementing
+ *    (mod 65536) for each physical turn of the device.  Our device
+ *    seems to alternate between two different values every third
+ *    packet.  One value increases, the other decreases.
+ *
+ *  \todo figure out if revolution is only present for one of the
+ *  two types of status fields
+ *
+ *  status has either a temperature encoding or the microcode level
+ */
+typedef struct raw_packet
+{
+  raw_block_t blocks[BLOCKS_PER_PACKET];
+  uint16_t revolution;
+  uint8_t status[PACKET_STATUS_SIZE];
+} raw_packet_t;
+
+/** \brief Velodyne data conversion class */
+class RawData
+{
+ public:
+  RawData();
+  ~RawData()
+  {
+  }
+
+  /** \brief Set up for data processing.
+   *
+   *  Perform initializations needed before data processing can
+   *  begin:
+   *
+   *    - read device-specific angles calibration
+   *
+   *  @param private_nh private node handle for ROS parameters
+   *  @returns 0 if successful;
+   *           errno value for failure
+   */
+  int setup(ros::NodeHandle private_nh);
+
+  float unpack(const velodyne_msgs::VelodynePacket& pkt, VPointCloud& pc, size_t* valid_pnts=nullptr) const;
+
+  void setParameters(double min_range, double max_range, double view_direction, double view_width);
+
+ private:
+  /** configuration parameters */
+  typedef struct
+  {
+    std::string calibrationFile; ///< calibration file name
+    std::string deviceModel;     ///< device model name
+    double max_range;            ///< maximum range to publish
+    double min_range;            ///< minimum range to publish
+    int min_angle;               ///< minimum angle to publish
+    int max_angle;               ///< maximum angle to publish
+
+    double tmp_min_angle;
+    double tmp_max_angle;
+  } Config;
+  Config config_;
 
   /**
-   * Raw Velodyne packet constants and structures.
+   * Calibration file
    */
-  static const int SIZE_BLOCK = 100;
-  static const int RAW_SCAN_SIZE = 3;
-  static const int SCANS_PER_BLOCK = 32;
-  static const int BLOCK_DATA_SIZE = (SCANS_PER_BLOCK * RAW_SCAN_SIZE);
+  velodyne_pointcloud::Calibration calibration_;
+  vlp_spec_t vlp_spec_;
+  bool is_vlp_; // whether or not device model is VLP
+  float sin_rot_table_[ROTATION_MAX_UNITS];
+  float cos_rot_table_[ROTATION_MAX_UNITS];
 
-  static const float ROTATION_RESOLUTION      =     0.01f;  // [deg]
-  static const uint16_t ROTATION_MAX_UNITS    = 36000u;     // [deg/100]
-  static const float DISTANCE_RESOLUTION      =     0.002f; // [m]
+  /** add private function to handle the VLP16 and VLP32 **/
+  float unpack_vlp(const velodyne_msgs::VelodynePacket& pkt, VPointCloud& pc, size_t* valid_pnts) const;
 
-  /** @todo make this work for both big and little-endian machines */
-  static const uint16_t UPPER_BANK = 0xeeff;
-  static const uint16_t LOWER_BANK = 0xddff;
-
-  /** Special defines for VLP support **/
-  typedef struct vlp_spec
+  /** in-line test whether a point is in range */
+  bool pointInRange(float range) const
   {
-    int firing_seqs_per_block;
-    int lasers_per_firing_seq;
-    int lasers_per_firing;
-    float firing_duration;     // [us]
-    float firing_seq_duration; // [us]
-    float block_duration;      // [us] = firing_seq_duration * firing_seqs_per_block
-    float distance_resolution; // [us]
-  } vlp_spec_t;
-
-  static const vlp_spec_t VLP_16_SPEC = {
-    2, 16, 1, 2.304f, 55.296f, 110.592f, 0.002f
-  };
-
-  static const vlp_spec_t VLP_32_SPEC = {
-    1, 32, 2, 2.304f, 55.296f, 55.296f, 0.004f
-  };
-
-  /** \brief Raw Velodyne data block.
-   *
-   *  Each block contains data from either the upper or lower laser
-   *  bank.  The device returns three times as many upper bank blocks.
-   *
-   *  use stdint.h types, so things work with both 64 and 32-bit machines
-   */
-  typedef struct raw_block
-  {
-    uint16_t header;        ///< UPPER_BANK or LOWER_BANK
-    uint16_t rotation;      ///< 0-35999, divide by 100 to get degrees
-    uint8_t  data[BLOCK_DATA_SIZE];
-  } raw_block_t;
-
-  /** used for unpacking the first two data bytes in a block
-   *
-   *  They are packed into the actual data stream misaligned.  I doubt
-   *  this works on big endian machines.
-   */
-  union two_bytes
-  {
-    uint16_t uint;
-    uint8_t  bytes[2];
-  };
-
-  static const int PACKET_SIZE = 1206;
-  static const int BLOCKS_PER_PACKET = 12;
-  static const int PACKET_STATUS_SIZE = 4;
-  static const int SCANS_PER_PACKET = (SCANS_PER_BLOCK * BLOCKS_PER_PACKET);
-
-  /** \brief Raw Velodyne packet.
-   *
-   *  revolution is described in the device manual as incrementing
-   *    (mod 65536) for each physical turn of the device.  Our device
-   *    seems to alternate between two different values every third
-   *    packet.  One value increases, the other decreases.
-   *
-   *  \todo figure out if revolution is only present for one of the
-   *  two types of status fields
-   *
-   *  status has either a temperature encoding or the microcode level
-   */
-  typedef struct raw_packet
-  {
-    raw_block_t blocks[BLOCKS_PER_PACKET];
-    uint16_t revolution;
-    uint8_t status[PACKET_STATUS_SIZE]; 
-  } raw_packet_t;
-
-  /** \brief Velodyne data conversion class */
-  class RawData
-  {
-  public:
-
-    RawData();
-    ~RawData() {}
-
-    /** \brief Set up for data processing.
-     *
-     *  Perform initializations needed before data processing can
-     *  begin:
-     *
-     *    - read device-specific angles calibration
-     *
-     *  @param private_nh private node handle for ROS parameters
-     *  @returns 0 if successful;
-     *           errno value for failure
-     */
-    int setup(ros::NodeHandle private_nh);
-
-    float unpack(const velodyne_msgs::VelodynePacket &pkt, VPointCloud &pc);
-    
-    void setParameters(double min_range, double max_range, double view_direction,
-                       double view_width);
-
-  private:
-
-    /** configuration parameters */
-    typedef struct {
-      std::string calibrationFile;     ///< calibration file name
-      std::string deviceModel;         ///< device model name
-      double max_range;                ///< maximum range to publish
-      double min_range;                ///< minimum range to publish
-      int min_angle;                   ///< minimum angle to publish
-      int max_angle;                   ///< maximum angle to publish
-      
-      double tmp_min_angle;
-      double tmp_max_angle;
-    } Config;
-    Config config_;
-
-    /** 
-     * Calibration file
-     */
-    velodyne_pointcloud::Calibration calibration_;
-    vlp_spec_t vlp_spec_;
-    bool is_vlp_; // whether or not device model is VLP
-    float sin_rot_table_[ROTATION_MAX_UNITS];
-    float cos_rot_table_[ROTATION_MAX_UNITS];
-    
-    /** add private function to handle the VLP16 and VLP32 **/
-    float unpack_vlp(const velodyne_msgs::VelodynePacket &pkt, VPointCloud &pc);
-
-    /** in-line test whether a point is in range */
-    bool pointInRange(float range)
-    {
-      return (range >= config_.min_range
-              && range <= config_.max_range);
-    }
-  };
+    return (range >= config_.min_range && range <= config_.max_range);
+  }
+};
 
 } // namespace velodyne_rawdata
 

--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -144,7 +144,7 @@ namespace velodyne_rawdata
      */
     int setup(ros::NodeHandle private_nh);
 
-    float unpack(const velodyne_msgs::VelodynePacket &pkt, VPointCloud &pc);
+    float unpackAndAdd(const velodyne_msgs::VelodynePacket &pkt, VPointCloud &pc);
     
     void setParameters(double min_range, double max_range, double view_direction,
                        double view_width);

--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -21,163 +21,169 @@
 #define __VELODYNE_RAWDATA_H
 
 #include <errno.h>
-#include <math.h>
 #include <stdint.h>
-#include <boost/format.hpp>
 #include <string>
+#include <boost/format.hpp>
+#include <math.h>
 
-#include <pcl_ros/point_cloud.h>
 #include <ros/ros.h>
+#include <pcl_ros/point_cloud.h>
 #include <velodyne_msgs/VelodyneScan.h>
-#include <velodyne_pointcloud/calibration.h>
 #include <velodyne_pointcloud/point_types.h>
+#include <velodyne_pointcloud/calibration.h>
 
-namespace velodyne_rawdata {
-// Shorthand typedefs for point cloud representations
-typedef velodyne_pointcloud::PointXYZIR VPoint;
-typedef pcl::PointCloud<VPoint> VPointCloud;
-
-/**
- * Raw Velodyne packet constants and structures.
- */
-static const int SIZE_BLOCK = 100;
-static const int RAW_SCAN_SIZE = 3;
-static const int SCANS_PER_BLOCK = 32;
-static const int BLOCK_DATA_SIZE = (SCANS_PER_BLOCK * RAW_SCAN_SIZE);
-
-static const float ROTATION_RESOLUTION = 0.01f;    // [deg]
-static const uint16_t ROTATION_MAX_UNITS = 36000u; // [deg/100]
-static const float DISTANCE_RESOLUTION = 0.002f;   // [m]
-
-/** @todo make this work for both big and little-endian machines */
-static const uint16_t UPPER_BANK = 0xeeff;
-static const uint16_t LOWER_BANK = 0xddff;
-
-/** Special defines for VLP support **/
-typedef struct vlp_spec
+namespace velodyne_rawdata
 {
-  int firing_seqs_per_block;
-  int lasers_per_firing_seq;
-  int lasers_per_firing;
-  float firing_duration;     // [us]
-  float firing_seq_duration; // [us]
-  float block_duration;      // [us] = firing_seq_duration * firing_seqs_per_block
-  float distance_resolution; // [us]
-} vlp_spec_t;
-
-static const vlp_spec_t VLP_16_SPEC = { 2, 16, 1, 2.304f, 55.296f, 110.592f, 0.002f };
-
-static const vlp_spec_t VLP_32_SPEC = { 1, 32, 2, 2.304f, 55.296f, 55.296f, 0.004f };
-
-/** \brief Raw Velodyne data block.
- *
- *  Each block contains data from either the upper or lower laser
- *  bank.  The device returns three times as many upper bank blocks.
- *
- *  use stdint.h types, so things work with both 64 and 32-bit machines
- */
-typedef struct raw_block
-{
-  uint16_t header;   ///< UPPER_BANK or LOWER_BANK
-  uint16_t rotation; ///< 0-35999, divide by 100 to get degrees
-  uint8_t data[BLOCK_DATA_SIZE];
-} raw_block_t;
-
-/** used for unpacking the first two data bytes in a block
- *
- *  They are packed into the actual data stream misaligned.  I doubt
- *  this works on big endian machines.
- */
-union two_bytes
-{
-  uint16_t uint;
-  uint8_t bytes[2];
-};
-
-static const int PACKET_SIZE = 1206;
-static const int BLOCKS_PER_PACKET = 12;
-static const int PACKET_STATUS_SIZE = 4;
-static const int SCANS_PER_PACKET = (SCANS_PER_BLOCK * BLOCKS_PER_PACKET);
-
-/** \brief Raw Velodyne packet.
- *
- *  revolution is described in the device manual as incrementing
- *    (mod 65536) for each physical turn of the device.  Our device
- *    seems to alternate between two different values every third
- *    packet.  One value increases, the other decreases.
- *
- *  \todo figure out if revolution is only present for one of the
- *  two types of status fields
- *
- *  status has either a temperature encoding or the microcode level
- */
-typedef struct raw_packet
-{
-  raw_block_t blocks[BLOCKS_PER_PACKET];
-  uint16_t revolution;
-  uint8_t status[PACKET_STATUS_SIZE];
-} raw_packet_t;
-
-/** \brief Velodyne data conversion class */
-class RawData
-{
- public:
-  RawData();
-  ~RawData()
-  {
-  }
-
-  /** \brief Set up for data processing.
-   *
-   *  Perform initializations needed before data processing can
-   *  begin:
-   *
-   *    - read device-specific angles calibration
-   *
-   *  @param private_nh private node handle for ROS parameters
-   *  @returns 0 if successful;
-   *           errno value for failure
-   */
-  int setup(ros::NodeHandle private_nh);
-
-  float unpackAndAdd(const velodyne_msgs::VelodynePacket& pkt, VPointCloud& pc, size_t* valid_pnts=nullptr) const;
-
-  void setParameters(double min_range, double max_range, double view_direction, double view_width);
-
- private:
-  /** configuration parameters */
-  typedef struct
-  {
-    std::string calibrationFile; ///< calibration file name
-    std::string deviceModel;     ///< device model name
-    double max_range;            ///< maximum range to publish
-    double min_range;            ///< minimum range to publish
-    int min_angle;               ///< minimum angle to publish
-    int max_angle;               ///< maximum angle to publish
-
-    double tmp_min_angle;
-    double tmp_max_angle;
-  } Config;
-  Config config_;
+  // Shorthand typedefs for point cloud representations
+  typedef velodyne_pointcloud::PointXYZIR VPoint;
+  typedef pcl::PointCloud<VPoint> VPointCloud;
 
   /**
-   * Calibration file
+   * Raw Velodyne packet constants and structures.
    */
-  velodyne_pointcloud::Calibration calibration_;
-  vlp_spec_t vlp_spec_;
-  bool is_vlp_; // whether or not device model is VLP
-  float sin_rot_table_[ROTATION_MAX_UNITS];
-  float cos_rot_table_[ROTATION_MAX_UNITS];
+  static const int SIZE_BLOCK = 100;
+  static const int RAW_SCAN_SIZE = 3;
+  static const int SCANS_PER_BLOCK = 32;
+  static const int BLOCK_DATA_SIZE = (SCANS_PER_BLOCK * RAW_SCAN_SIZE);
 
-  /** add private function to handle the VLP16 and VLP32 **/
-  float unpack_vlp(const velodyne_msgs::VelodynePacket& pkt, VPointCloud& pc, size_t* valid_pnts) const;
+  static const float ROTATION_RESOLUTION      =     0.01f;  // [deg]
+  static const uint16_t ROTATION_MAX_UNITS    = 36000u;     // [deg/100]
+  static const float DISTANCE_RESOLUTION      =     0.002f; // [m]
 
-  /** in-line test whether a point is in range */
-  bool pointInRange(float range) const
+  /** @todo make this work for both big and little-endian machines */
+  static const uint16_t UPPER_BANK = 0xeeff;
+  static const uint16_t LOWER_BANK = 0xddff;
+
+  /** Special defines for VLP support **/
+  typedef struct vlp_spec
   {
-    return (range >= config_.min_range && range <= config_.max_range);
-  }
-};
+    int firing_seqs_per_block;
+    int lasers_per_firing_seq;
+    int lasers_per_firing;
+    float firing_duration;     // [us]
+    float firing_seq_duration; // [us]
+    float block_duration;      // [us] = firing_seq_duration * firing_seqs_per_block
+    float distance_resolution; // [us]
+  } vlp_spec_t;
+
+  static const vlp_spec_t VLP_16_SPEC = {
+    2, 16, 1, 2.304f, 55.296f, 110.592f, 0.002f
+  };
+
+  static const vlp_spec_t VLP_32_SPEC = {
+    1, 32, 2, 2.304f, 55.296f, 55.296f, 0.004f
+  };
+
+  /** \brief Raw Velodyne data block.
+   *
+   *  Each block contains data from either the upper or lower laser
+   *  bank.  The device returns three times as many upper bank blocks.
+   *
+   *  use stdint.h types, so things work with both 64 and 32-bit machines
+   */
+  typedef struct raw_block
+  {
+    uint16_t header;        ///< UPPER_BANK or LOWER_BANK
+    uint16_t rotation;      ///< 0-35999, divide by 100 to get degrees
+    uint8_t  data[BLOCK_DATA_SIZE];
+  } raw_block_t;
+
+  /** used for unpacking the first two data bytes in a block
+   *
+   *  They are packed into the actual data stream misaligned.  I doubt
+   *  this works on big endian machines.
+   */
+  union two_bytes
+  {
+    uint16_t uint;
+    uint8_t  bytes[2];
+  };
+
+  static const int PACKET_SIZE = 1206;
+  static const int BLOCKS_PER_PACKET = 12;
+  static const int PACKET_STATUS_SIZE = 4;
+  static const int SCANS_PER_PACKET = (SCANS_PER_BLOCK * BLOCKS_PER_PACKET);
+
+  /** \brief Raw Velodyne packet.
+   *
+   *  revolution is described in the device manual as incrementing
+   *    (mod 65536) for each physical turn of the device.  Our device
+   *    seems to alternate between two different values every third
+   *    packet.  One value increases, the other decreases.
+   *
+   *  \todo figure out if revolution is only present for one of the
+   *  two types of status fields
+   *
+   *  status has either a temperature encoding or the microcode level
+   */
+  typedef struct raw_packet
+  {
+    raw_block_t blocks[BLOCKS_PER_PACKET];
+    uint16_t revolution;
+    uint8_t status[PACKET_STATUS_SIZE]; 
+  } raw_packet_t;
+
+  /** \brief Velodyne data conversion class */
+  class RawData
+  {
+  public:
+
+    RawData();
+    ~RawData() {}
+
+    /** \brief Set up for data processing.
+     *
+     *  Perform initializations needed before data processing can
+     *  begin:
+     *
+     *    - read device-specific angles calibration
+     *
+     *  @param private_nh private node handle for ROS parameters
+     *  @returns 0 if successful;
+     *           errno value for failure
+     */
+    int setup(ros::NodeHandle private_nh);
+
+    float unpack(const velodyne_msgs::VelodynePacket &pkt, VPointCloud &pc);
+    
+    void setParameters(double min_range, double max_range, double view_direction,
+                       double view_width);
+
+  private:
+
+    /** configuration parameters */
+    typedef struct {
+      std::string calibrationFile;     ///< calibration file name
+      std::string deviceModel;         ///< device model name
+      double max_range;                ///< maximum range to publish
+      double min_range;                ///< minimum range to publish
+      int min_angle;                   ///< minimum angle to publish
+      int max_angle;                   ///< maximum angle to publish
+      
+      double tmp_min_angle;
+      double tmp_max_angle;
+    } Config;
+    Config config_;
+
+    /** 
+     * Calibration file
+     */
+    velodyne_pointcloud::Calibration calibration_;
+    vlp_spec_t vlp_spec_;
+    bool is_vlp_; // whether or not device model is VLP
+    float sin_rot_table_[ROTATION_MAX_UNITS];
+    float cos_rot_table_[ROTATION_MAX_UNITS];
+    
+    /** add private function to handle the VLP16 and VLP32 **/
+    float unpack_vlp(const velodyne_msgs::VelodynePacket &pkt, VPointCloud &pc);
+
+    /** in-line test whether a point is in range */
+    bool pointInRange(float range)
+    {
+      return (range >= config_.min_range
+              && range <= config_.max_range);
+    }
+  };
 
 } // namespace velodyne_rawdata
 

--- a/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
+++ b/velodyne_pointcloud/include/velodyne_pointcloud/rawdata.h
@@ -144,7 +144,13 @@ namespace velodyne_rawdata
      */
     int setup(ros::NodeHandle private_nh);
 
-    float unpackAndAdd(const velodyne_msgs::VelodynePacket &pkt, VPointCloud &pc);
+    /**
+     * Unpack pkt points, filter based on configuration, and add OK points to pc.
+     * @param pkt velodyne UDP packet payload (no UDP header)
+     * @param pc output pointcloud that we add data to
+     * @return azimuth value of the last point in pkt if VLP otherwise -1.0
+     */
+    float unpackAndAdd(const velodyne_msgs::VelodynePacket &pkt, VPointCloud &pc) const;
     
     void setParameters(double min_range, double max_range, double view_direction,
                        double view_width);
@@ -175,10 +181,10 @@ namespace velodyne_rawdata
     float cos_rot_table_[ROTATION_MAX_UNITS];
     
     /** add private function to handle the VLP16 and VLP32 **/
-    float unpack_vlp(const velodyne_msgs::VelodynePacket &pkt, VPointCloud &pc);
+    float unpack_vlp(const velodyne_msgs::VelodynePacket &pkt, VPointCloud &pc) const;
 
     /** in-line test whether a point is in range */
-    bool pointInRange(float range)
+    bool pointInRange(float range) const
     {
       return (range >= config_.min_range
               && range <= config_.max_range);

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -26,10 +26,10 @@ Convert::Convert(ros::NodeHandle node, ros::NodeHandle private_nh)
 
 
   // advertise output point cloud (before subscribing to input data)
-  output_pointcloud_ = node.advertise<sensor_msgs::PointCloud2>("velodyne_points", 10);
+  pointcloud_publisher_ = node.advertise<sensor_msgs::PointCloud2>("velodyne_points", 10);
 
   // advertise output deskew info
-  output_deskew_info_ =
+  deskew_info_publisher_ =
       node.advertise<velodyne_msgs::VelodyneDeskewInfo>("velodyne_deskew_info", 10);
 
   srv_ = boost::make_shared<dynamic_reconfigure::Server<velodyne_pointcloud::CloudNodeConfig> >(
@@ -37,6 +37,11 @@ Convert::Convert(ros::NodeHandle node, ros::NodeHandle private_nh)
   dynamic_reconfigure::Server<velodyne_pointcloud::CloudNodeConfig>::CallbackType f;
   f = boost::bind(&Convert::callback, this, _1, _2);
   srv_->setCallback(f);
+
+  prev_azimuth_ = 0.0f;
+  accumulated_cloud_.height = 1;
+  accumulated_cloud_.width = 0;
+  accumulated_cloud_.points.clear();
 
   // Add an extra entry for angle 0, for initial sweep
   deskew_info_.sweep_info.push_back(create_sweep_entry(prev_stamp_, 0.0));
@@ -61,24 +66,8 @@ velodyne_msgs::VelodyneSweepInfo Convert::create_sweep_entry(ros::Time stamp, fl
   return sweep_info;
 }
 
-/** @brief Callback for raw scan messages. */
 void Convert::processScan(const velodyne_msgs::VelodyneScan::ConstPtr& scanMsg)
 {
-  if (output_pointcloud_.getNumSubscribers() == 0) // no one listening?
-    return;                                        // avoid much work
-
-  // allocate a point cloud with same time and frame ID as raw data
-  velodyne_rawdata::VPointCloud::Ptr outMsg(new velodyne_rawdata::VPointCloud());
-
-  // outMsg's header is a pcl::PCLHeader, convert it before stamp assignment
-  outMsg->header.stamp = pcl_conversions::toPCL(scanMsg->header).stamp;
-  outMsg->header.frame_id = scanMsg->header.frame_id;
-  outMsg->height = 1;
-
-  // Debug
-  // std::cout << "Processing scan!\n";
-
-  // process each packet provided by the driver
   for (size_t i = 0; i < scanMsg->packets.size(); ++i) {
     const velodyne_rawdata::raw_packet_t* raw =
         (const velodyne_rawdata::raw_packet_t*)&scanMsg->packets[i].data[0];
@@ -87,17 +76,122 @@ void Convert::processScan(const velodyne_msgs::VelodyneScan::ConstPtr& scanMsg)
     float azimuth = float(raw->blocks[0].rotation) / 100.0;
 
     // azimuth value will wrap around after a full 360 degree sweep
-    // once we save all packets for the last full 360 degrees, publish them
     if (azimuth < prev_azimuth_) {
-      accumulated_cloud_.header.stamp = outMsg->header.stamp;
-      accumulated_cloud_.header.frame_id = outMsg->header.frame_id;
-      accumulated_cloud_.height = outMsg->height;
+      ROS_INFO("Azimuth = %.2f (prev = %.2f), publish", azimuth, prev_azimuth_);
+
+      // Publish data for the full sweep
+      accumulated_cloud_.header.stamp = pcl_conversions::toPCL(scanMsg->header).stamp;
+      accumulated_cloud_.header.frame_id = scanMsg->header.frame_id;
+      assert(accumulated_cloud_.width == accumulated_cloud_.points.size());
       accumulated_cloud_.width = accumulated_cloud_.points.size();
-      output_pointcloud_.publish(accumulated_cloud_);
+
+      size_t actual_cnt =
+          std::accumulate(packet_sizes_for_scan_.begin(), packet_sizes_for_scan_.end(), 0);
+      ROS_INFO("Full sweep sz: %lu, expected cnt: %lu, from: %lu PKT",
+               accumulated_cloud_.points.size(), actual_cnt, packet_sizes_for_scan_.size());
+      pointcloud_publisher_.publish(accumulated_cloud_);
 
       deskew_info_.header.stamp = scanMsg->header.stamp;
       deskew_info_.header.frame_id = scanMsg->header.frame_id;
-      output_deskew_info_.publish(deskew_info_);
+      deskew_info_publisher_.publish(deskew_info_);
+
+      std::cout << "az for scan: [";
+      for (float az : azimuth_for_scan_) {
+        std::cout << az << ", ";
+      }
+      std::cout << "]" << std::endl;
+
+      // Clear data we are accumulating
+      accumulated_cloud_.points.clear();
+      accumulated_cloud_.width = 0;
+      deskew_info_.sweep_info.clear();
+      packet_sizes_for_scan_.clear();
+      azimuth_for_scan_.clear();
+
+      // Add an extra entry for angle 0, for next sweep
+      deskew_info_.sweep_info.push_back(create_sweep_entry(prev_stamp_, 0.0));
+    }
+
+    azimuth_for_scan_.push_back(azimuth);
+
+    size_t valid_points_for_packet;
+    data_->unpack(scanMsg->packets[i], accumulated_cloud_, &valid_points_for_packet);
+    packet_sizes_for_scan_.push_back(valid_points_for_packet);
+
+    deskew_info_.sweep_info.push_back(create_sweep_entry(scanMsg->packets[i].stamp, azimuth));
+    prev_azimuth_ = azimuth;
+    prev_stamp_ = scanMsg->packets[i].stamp;
+  }
+}
+
+/** @brief Callback for raw scan messages. */
+void Convert::processScanBUGGED(const velodyne_msgs::VelodyneScan::ConstPtr& scanMsg)
+{
+  if (pointcloud_publisher_.getNumSubscribers() == 0) // no one listening?
+    return;                                           // avoid much work
+
+  // allocate a point cloud with same time and frame ID as raw data
+  velodyne_rawdata::VPointCloud::Ptr partial_scan_pointcloud(new velodyne_rawdata::VPointCloud());
+
+  // outMsg's header is a pcl::PCLHeader, convert it before stamp assignment
+  partial_scan_pointcloud->header.stamp = pcl_conversions::toPCL(scanMsg->header).stamp;
+  partial_scan_pointcloud->header.frame_id = scanMsg->header.frame_id;
+  partial_scan_pointcloud->height = 1;
+
+  ROS_INFO("Processing %lu packets", scanMsg->packets.size());
+
+  // process each packet provided by the driver
+  for (size_t i = 0; i < scanMsg->packets.size(); ++i) {
+    const velodyne_rawdata::raw_packet_t* raw =
+        (const velodyne_rawdata::raw_packet_t*)&scanMsg->packets[i].data[0];
+
+    u_int64_t pkt_checksum = 0;
+    for (int j = 0; j < velodyne_rawdata::PACKET_SIZE - 6;
+         ++j) { // don't include timestamp and factory
+      pkt_checksum += reinterpret_cast<const u_int8_t*>(raw)[j] * j;
+    }
+    if (packet_checksums_.count(pkt_checksum) == 0) {
+      packet_checksums_.insert(pkt_checksum);
+    } else {
+      ROS_WARN("Identical packet checksum!");
+    }
+
+    // azimuth corresponds to the starting sweep angle for the current packet
+    float azimuth = float(raw->blocks[0].rotation) / 100.0;
+
+    // azimuth value will wrap around after a full 360 degree sweep
+    // once we save all packets for the last full 360 degrees, publish them
+    if (azimuth < prev_azimuth_) {
+      accumulated_cloud_.header.stamp = partial_scan_pointcloud->header.stamp;
+      accumulated_cloud_.header.frame_id = partial_scan_pointcloud->header.frame_id;
+      accumulated_cloud_.height = partial_scan_pointcloud->height;
+      accumulated_cloud_.width = accumulated_cloud_.points.size();
+
+      size_t actual_cnt =
+          std::accumulate(packet_sizes_for_scan_.begin(), packet_sizes_for_scan_.end(), 0);
+      ROS_INFO("Full sweep sz: %lu, expected cnt: %lu", accumulated_cloud_.points.size(),
+               actual_cnt);
+      pointcloud_publisher_.publish(accumulated_cloud_);
+
+      for (size_t j = 0; j < accumulated_cloud_.points.size(); ++j) {
+        const velodyne_rawdata::VPoint& pnt = accumulated_cloud_.points[j];
+        auto pnt_tuple = std::make_tuple(pnt.x, pnt.y, pnt.z);
+        if (pnts_set_.count(pnt_tuple) == 0) {
+          pnts_set_.insert(pnt_tuple);
+        } else {
+          duplicates_++;
+        }
+      }
+      ROS_INFO("Num duplicates: %lu", duplicates_);
+      std::cout << "Valid counts for scan: ";
+      for (size_t n_valid : packet_sizes_for_scan_) {
+        std::cout << n_valid << ",";
+      }
+      std::cout << std::endl;
+
+      deskew_info_.header.stamp = scanMsg->header.stamp;
+      deskew_info_.header.frame_id = scanMsg->header.frame_id;
+      deskew_info_publisher_.publish(deskew_info_);
 
       accumulated_cloud_.points.clear();
       accumulated_cloud_.width = 0;
@@ -105,12 +199,21 @@ void Convert::processScan(const velodyne_msgs::VelodyneScan::ConstPtr& scanMsg)
 
       // Add an extra entry for angle 0, for next sweep
       deskew_info_.sweep_info.push_back(create_sweep_entry(prev_stamp_, 0.0));
+
+      packet_sizes_for_scan_.clear();
+      packet_checksums_.clear();
+      duplicates_ = 0;
+      pnts_set_.clear();
     }
 
-    data_->unpack(scanMsg->packets[i], *outMsg);
+    size_t valid_points_for_packet;
+    data_->unpack(scanMsg->packets[i], *partial_scan_pointcloud, &valid_points_for_packet);
+    packet_sizes_for_scan_.push_back(valid_points_for_packet);
+
     // Accumulate the pt cloud
-    accumulated_cloud_.points.insert(accumulated_cloud_.points.end(), outMsg->points.begin(),
-                                     outMsg->points.end());
+    accumulated_cloud_.points.insert(accumulated_cloud_.points.end(),
+                                     partial_scan_pointcloud->points.begin(),
+                                     partial_scan_pointcloud->points.end());
 
     // Get the sweep info
     deskew_info_.sweep_info.push_back(create_sweep_entry(scanMsg->packets[i].stamp, azimuth));

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -24,6 +24,8 @@ Convert::Convert(ros::NodeHandle node, ros::NodeHandle private_nh)
 {
   data_->setup(private_nh);
 
+  accumulated_cloud_.width = 0;
+  accumulated_cloud_.height = 1;
 
   // advertise output point cloud (before subscribing to input data)
   pointcloud_publisher_ = node.advertise<sensor_msgs::PointCloud2>("velodyne_points", 10);
@@ -64,21 +66,6 @@ velodyne_msgs::VelodyneSweepInfo Convert::create_sweep_entry(ros::Time stamp, fl
 /** @brief Callback for raw scan messages. */
 void Convert::processScan(const velodyne_msgs::VelodyneScan::ConstPtr& scanMsg)
 {
-  if (pointcloud_publisher_.getNumSubscribers() == 0) // no one listening?
-    return;                                           // avoid much work
-
-  // allocate a point cloud with same time and frame ID as raw data
-  velodyne_rawdata::VPointCloud::Ptr outMsg(new velodyne_rawdata::VPointCloud());
-
-  // outMsg's header is a pcl::PCLHeader, convert it before stamp assignment
-  outMsg->header.stamp = pcl_conversions::toPCL(scanMsg->header).stamp;
-  outMsg->header.frame_id = scanMsg->header.frame_id;
-  outMsg->height = 1;
-
-  // Debug
-  // std::cout << "Processing scan!\n";
-
-  // process each packet provided by the driver
   for (size_t i = 0; i < scanMsg->packets.size(); ++i) {
     const velodyne_rawdata::raw_packet_t* raw =
         (const velodyne_rawdata::raw_packet_t*)&scanMsg->packets[i].data[0];
@@ -87,18 +74,19 @@ void Convert::processScan(const velodyne_msgs::VelodyneScan::ConstPtr& scanMsg)
     float azimuth = float(raw->blocks[0].rotation) / 100.0;
 
     // azimuth value will wrap around after a full 360 degree sweep
-    // once we save all packets for the last full 360 degrees, publish them
     if (azimuth < prev_azimuth_) {
-      accumulated_cloud_.header.stamp = outMsg->header.stamp;
-      accumulated_cloud_.header.frame_id = outMsg->header.frame_id;
-      accumulated_cloud_.height = outMsg->height;
-      accumulated_cloud_.width = accumulated_cloud_.points.size();
+      // Publish data for the full sweep
+      accumulated_cloud_.header.stamp = pcl_conversions::toPCL(scanMsg->header).stamp;
+      accumulated_cloud_.header.frame_id = scanMsg->header.frame_id;
+      assert(accumulated_cloud_.width == accumulated_cloud_.points.size());
+
       pointcloud_publisher_.publish(accumulated_cloud_);
 
       deskew_info_.header.stamp = scanMsg->header.stamp;
       deskew_info_.header.frame_id = scanMsg->header.frame_id;
       deskew_info_publisher_.publish(deskew_info_);
 
+      // Clear data we are accumulating
       accumulated_cloud_.points.clear();
       accumulated_cloud_.width = 0;
       deskew_info_.sweep_info.clear();
@@ -107,14 +95,9 @@ void Convert::processScan(const velodyne_msgs::VelodyneScan::ConstPtr& scanMsg)
       deskew_info_.sweep_info.push_back(create_sweep_entry(prev_stamp_, 0.0));
     }
 
-    data_->unpackAndAdd(scanMsg->packets[i], *outMsg);
-    // Accumulate the pt cloud
-    accumulated_cloud_.points.insert(accumulated_cloud_.points.end(), outMsg->points.begin(),
-                                     outMsg->points.end());
+    data_->unpackAndAdd(scanMsg->packets[i], accumulated_cloud_);
 
-    // Get the sweep info
     deskew_info_.sweep_info.push_back(create_sweep_entry(scanMsg->packets[i].stamp, azimuth));
-
     prev_azimuth_ = azimuth;
     prev_stamp_ = scanMsg->packets[i].stamp;
   }

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -26,10 +26,10 @@ Convert::Convert(ros::NodeHandle node, ros::NodeHandle private_nh)
 
 
   // advertise output point cloud (before subscribing to input data)
-  pointcloud_publisher_ = node.advertise<sensor_msgs::PointCloud2>("velodyne_points", 10);
+  output_pointcloud_ = node.advertise<sensor_msgs::PointCloud2>("velodyne_points", 10);
 
   // advertise output deskew info
-  deskew_info_publisher_ =
+  output_deskew_info_ =
       node.advertise<velodyne_msgs::VelodyneDeskewInfo>("velodyne_deskew_info", 10);
 
   srv_ = boost::make_shared<dynamic_reconfigure::Server<velodyne_pointcloud::CloudNodeConfig> >(
@@ -37,11 +37,6 @@ Convert::Convert(ros::NodeHandle node, ros::NodeHandle private_nh)
   dynamic_reconfigure::Server<velodyne_pointcloud::CloudNodeConfig>::CallbackType f;
   f = boost::bind(&Convert::callback, this, _1, _2);
   srv_->setCallback(f);
-
-  prev_azimuth_ = 0.0f;
-  accumulated_cloud_.height = 1;
-  accumulated_cloud_.width = 0;
-  accumulated_cloud_.points.clear();
 
   // Add an extra entry for angle 0, for initial sweep
   deskew_info_.sweep_info.push_back(create_sweep_entry(prev_stamp_, 0.0));
@@ -66,76 +61,27 @@ velodyne_msgs::VelodyneSweepInfo Convert::create_sweep_entry(ros::Time stamp, fl
   return sweep_info;
 }
 
+/** @brief Callback for raw scan messages. */
 void Convert::processScan(const velodyne_msgs::VelodyneScan::ConstPtr& scanMsg)
 {
-  for (size_t i = 0; i < scanMsg->packets.size(); ++i) {
-    const velodyne_rawdata::raw_packet_t* raw =
-        (const velodyne_rawdata::raw_packet_t*)&scanMsg->packets[i].data[0];
-
-    // azimuth corresponds to the starting sweep angle for the current packet
-    float azimuth = float(raw->blocks[0].rotation) / 100.0;
-
-    // azimuth value will wrap around after a full 360 degree sweep
-    if (azimuth < prev_azimuth_) {
-      // Publish data for the full sweep
-      accumulated_cloud_.header.stamp = pcl_conversions::toPCL(scanMsg->header).stamp;
-      accumulated_cloud_.header.frame_id = scanMsg->header.frame_id;
-      assert(accumulated_cloud_.width == accumulated_cloud_.points.size());
-
-      pointcloud_publisher_.publish(accumulated_cloud_);
-
-      deskew_info_.header.stamp = scanMsg->header.stamp;
-      deskew_info_.header.frame_id = scanMsg->header.frame_id;
-      deskew_info_publisher_.publish(deskew_info_);
-
-      // Clear data we are accumulating
-      accumulated_cloud_.points.clear();
-      accumulated_cloud_.width = 0;
-      deskew_info_.sweep_info.clear();
-
-      // Add an extra entry for angle 0, for next sweep
-      deskew_info_.sweep_info.push_back(create_sweep_entry(prev_stamp_, 0.0));
-    }
-
-    data_->unpackAndAdd(scanMsg->packets[i], accumulated_cloud_);
-
-    deskew_info_.sweep_info.push_back(create_sweep_entry(scanMsg->packets[i].stamp, azimuth));
-    prev_azimuth_ = azimuth;
-    prev_stamp_ = scanMsg->packets[i].stamp;
-  }
-}
-
-/** @brief Callback for raw scan messages. */
-void Convert::processScanBUGGED(const velodyne_msgs::VelodyneScan::ConstPtr& scanMsg)
-{
-  if (pointcloud_publisher_.getNumSubscribers() == 0) // no one listening?
-    return;                                           // avoid much work
+  if (output_pointcloud_.getNumSubscribers() == 0) // no one listening?
+    return;                                        // avoid much work
 
   // allocate a point cloud with same time and frame ID as raw data
-  velodyne_rawdata::VPointCloud::Ptr partial_scan_pointcloud(new velodyne_rawdata::VPointCloud());
+  velodyne_rawdata::VPointCloud::Ptr outMsg(new velodyne_rawdata::VPointCloud());
 
   // outMsg's header is a pcl::PCLHeader, convert it before stamp assignment
-  partial_scan_pointcloud->header.stamp = pcl_conversions::toPCL(scanMsg->header).stamp;
-  partial_scan_pointcloud->header.frame_id = scanMsg->header.frame_id;
-  partial_scan_pointcloud->height = 1;
+  outMsg->header.stamp = pcl_conversions::toPCL(scanMsg->header).stamp;
+  outMsg->header.frame_id = scanMsg->header.frame_id;
+  outMsg->height = 1;
 
-  ROS_INFO("Processing %lu packets", scanMsg->packets.size());
+  // Debug
+  // std::cout << "Processing scan!\n";
 
   // process each packet provided by the driver
   for (size_t i = 0; i < scanMsg->packets.size(); ++i) {
     const velodyne_rawdata::raw_packet_t* raw =
         (const velodyne_rawdata::raw_packet_t*)&scanMsg->packets[i].data[0];
-
-    u_int64_t pkt_checksum = 0;
-    for (int j = 0; j < velodyne_rawdata::PACKET_SIZE - 6;
-         ++j) { // don't include timestamp and factory
-      pkt_checksum += reinterpret_cast<const u_int8_t*>(raw)[j] * j;
-    }
-    if (packet_checksums_.count(pkt_checksum) == 0) {
-      packet_checksums_.insert(pkt_checksum);
-    } else {
-      ROS_WARN("Identical packet checksum!");
-    }
 
     // azimuth corresponds to the starting sweep angle for the current packet
     float azimuth = float(raw->blocks[0].rotation) / 100.0;
@@ -143,36 +89,15 @@ void Convert::processScanBUGGED(const velodyne_msgs::VelodyneScan::ConstPtr& sca
     // azimuth value will wrap around after a full 360 degree sweep
     // once we save all packets for the last full 360 degrees, publish them
     if (azimuth < prev_azimuth_) {
-      accumulated_cloud_.header.stamp = partial_scan_pointcloud->header.stamp;
-      accumulated_cloud_.header.frame_id = partial_scan_pointcloud->header.frame_id;
-      accumulated_cloud_.height = partial_scan_pointcloud->height;
+      accumulated_cloud_.header.stamp = outMsg->header.stamp;
+      accumulated_cloud_.header.frame_id = outMsg->header.frame_id;
+      accumulated_cloud_.height = outMsg->height;
       accumulated_cloud_.width = accumulated_cloud_.points.size();
-
-      size_t actual_cnt =
-          std::accumulate(packet_sizes_for_scan_.begin(), packet_sizes_for_scan_.end(), 0);
-      ROS_INFO("Full sweep sz: %lu, expected cnt: %lu", accumulated_cloud_.points.size(),
-               actual_cnt);
-      pointcloud_publisher_.publish(accumulated_cloud_);
-
-      for (size_t j = 0; j < accumulated_cloud_.points.size(); ++j) {
-        const velodyne_rawdata::VPoint& pnt = accumulated_cloud_.points[j];
-        auto pnt_tuple = std::make_tuple(pnt.x, pnt.y, pnt.z);
-        if (pnts_set_.count(pnt_tuple) == 0) {
-          pnts_set_.insert(pnt_tuple);
-        } else {
-          duplicates_++;
-        }
-      }
-      ROS_INFO("Num duplicates: %lu", duplicates_);
-      std::cout << "Valid counts for scan: ";
-      for (size_t n_valid : packet_sizes_for_scan_) {
-        std::cout << n_valid << ",";
-      }
-      std::cout << std::endl;
+      output_pointcloud_.publish(accumulated_cloud_);
 
       deskew_info_.header.stamp = scanMsg->header.stamp;
       deskew_info_.header.frame_id = scanMsg->header.frame_id;
-      deskew_info_publisher_.publish(deskew_info_);
+      output_deskew_info_.publish(deskew_info_);
 
       accumulated_cloud_.points.clear();
       accumulated_cloud_.width = 0;
@@ -180,21 +105,12 @@ void Convert::processScanBUGGED(const velodyne_msgs::VelodyneScan::ConstPtr& sca
 
       // Add an extra entry for angle 0, for next sweep
       deskew_info_.sweep_info.push_back(create_sweep_entry(prev_stamp_, 0.0));
-
-      packet_sizes_for_scan_.clear();
-      packet_checksums_.clear();
-      duplicates_ = 0;
-      pnts_set_.clear();
     }
 
-    size_t valid_points_for_packet;
-    data_->unpackAndAdd(scanMsg->packets[i], *partial_scan_pointcloud, &valid_points_for_packet);
-    packet_sizes_for_scan_.push_back(valid_points_for_packet);
-
+    data_->unpack(scanMsg->packets[i], *outMsg);
     // Accumulate the pt cloud
-    accumulated_cloud_.points.insert(accumulated_cloud_.points.end(),
-                                     partial_scan_pointcloud->points.begin(),
-                                     partial_scan_pointcloud->points.end());
+    accumulated_cloud_.points.insert(accumulated_cloud_.points.end(), outMsg->points.begin(),
+                                     outMsg->points.end());
 
     // Get the sweep info
     deskew_info_.sweep_info.push_back(create_sweep_entry(scanMsg->packets[i].stamp, azimuth));

--- a/velodyne_pointcloud/src/conversions/convert.h
+++ b/velodyne_pointcloud/src/conversions/convert.h
@@ -28,6 +28,7 @@
 #include <velodyne_msgs/VelodyneDeskewInfo.h>
 #include <velodyne_msgs/VelodyneSweepInfo.h>
 
+
 namespace velodyne_pointcloud {
 class Convert
 {
@@ -41,19 +42,31 @@ class Convert
   void callback(velodyne_pointcloud::CloudNodeConfig& config, uint32_t level);
   velodyne_msgs::VelodyneSweepInfo create_sweep_entry(ros::Time stamp, float angle);
   void processScan(const velodyne_msgs::VelodyneScan::ConstPtr& scanMsg);
+  void processScanBUGGED(const velodyne_msgs::VelodyneScan::ConstPtr& scanMsg);
 
   /// Pointer to dynamic reconfigure service srv_
   boost::shared_ptr<dynamic_reconfigure::Server<velodyne_pointcloud::CloudNodeConfig> > srv_;
 
   boost::shared_ptr<velodyne_rawdata::RawData> data_;
   ros::Subscriber velodyne_scan_;
-  ros::Publisher output_pointcloud_, output_deskew_info_;
+  ros::Publisher pointcloud_publisher_;
+  ros::Publisher deskew_info_publisher_;
 
   // make the pointcloud container a member variable to append different slices
   velodyne_rawdata::VPointCloud accumulated_cloud_;
   velodyne_msgs::VelodyneDeskewInfo deskew_info_;
   float prev_azimuth_;
   ros::Time prev_stamp_;
+
+  // Let's check the sum of the packates, should be very unlikely to get the same number twice...
+  std::set<u_int64_t> packet_checksums_;
+  size_t duplicates_ = 0;
+  std::set<std::tuple<float,float,float>> pnts_set_; // expensive -- just bug-hunting!!!
+
+  std::vector<size_t> packet_sizes_for_scan_;
+
+  std::vector<float> azimuth_for_scan_;
+
   /// configuration parameters
   typedef struct
   {

--- a/velodyne_pointcloud/src/conversions/convert.h
+++ b/velodyne_pointcloud/src/conversions/convert.h
@@ -28,7 +28,6 @@
 #include <velodyne_msgs/VelodyneDeskewInfo.h>
 #include <velodyne_msgs/VelodyneSweepInfo.h>
 
-
 namespace velodyne_pointcloud {
 class Convert
 {
@@ -42,31 +41,19 @@ class Convert
   void callback(velodyne_pointcloud::CloudNodeConfig& config, uint32_t level);
   velodyne_msgs::VelodyneSweepInfo create_sweep_entry(ros::Time stamp, float angle);
   void processScan(const velodyne_msgs::VelodyneScan::ConstPtr& scanMsg);
-  void processScanBUGGED(const velodyne_msgs::VelodyneScan::ConstPtr& scanMsg);
 
   /// Pointer to dynamic reconfigure service srv_
   boost::shared_ptr<dynamic_reconfigure::Server<velodyne_pointcloud::CloudNodeConfig> > srv_;
 
   boost::shared_ptr<velodyne_rawdata::RawData> data_;
   ros::Subscriber velodyne_scan_;
-  ros::Publisher pointcloud_publisher_;
-  ros::Publisher deskew_info_publisher_;
+  ros::Publisher output_pointcloud_, output_deskew_info_;
 
   // make the pointcloud container a member variable to append different slices
   velodyne_rawdata::VPointCloud accumulated_cloud_;
   velodyne_msgs::VelodyneDeskewInfo deskew_info_;
   float prev_azimuth_;
   ros::Time prev_stamp_;
-
-  // Let's check the sum of the packates, should be very unlikely to get the same number twice...
-  std::set<u_int64_t> packet_checksums_;
-  size_t duplicates_ = 0;
-  std::set<std::tuple<float,float,float>> pnts_set_; // expensive -- just bug-hunting!!!
-
-  std::vector<size_t> packet_sizes_for_scan_;
-
-  std::vector<float> azimuth_for_scan_;
-
   /// configuration parameters
   typedef struct
   {

--- a/velodyne_pointcloud/src/conversions/convert.h
+++ b/velodyne_pointcloud/src/conversions/convert.h
@@ -47,7 +47,7 @@ class Convert
 
   boost::shared_ptr<velodyne_rawdata::RawData> data_;
   ros::Subscriber velodyne_scan_;
-  ros::Publisher output_pointcloud_, output_deskew_info_;
+  ros::Publisher pointcloud_publisher_, deskew_info_publisher_;
 
   // make the pointcloud container a member variable to append different slices
   velodyne_rawdata::VPointCloud accumulated_cloud_;

--- a/velodyne_pointcloud/src/conversions/transform.cc
+++ b/velodyne_pointcloud/src/conversions/transform.cc
@@ -91,7 +91,7 @@ namespace velodyne_pointcloud
         pcl_conversions::toPCL(header, inPc_.header);
 
         // unpack the raw data
-        data_->unpack(scanMsg->packets[next], inPc_);
+        data_->unpackAndAdd(scanMsg->packets[next], inPc_);
 
         // clear transform point cloud for this packet
         tfPc_.points.clear();           // is this needed?

--- a/velodyne_pointcloud/src/conversions/transform.cc
+++ b/velodyne_pointcloud/src/conversions/transform.cc
@@ -91,7 +91,7 @@ namespace velodyne_pointcloud
         pcl_conversions::toPCL(header, inPc_.header);
 
         // unpack the raw data
-        data_->unpackAndAdd(scanMsg->packets[next], inPc_);
+        data_->unpack(scanMsg->packets[next], inPc_);
 
         // clear transform point cloud for this packet
         tfPc_.points.clear();           // is this needed?

--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -25,501 +25,456 @@
  *  HDL-64E S2 calibration support provided by Nick Hillier
  */
 
-#include <math.h>
 #include <fstream>
+#include <math.h>
 
-#include <angles/angles.h>
-#include <ros/package.h>
 #include <ros/ros.h>
+#include <ros/package.h>
+#include <angles/angles.h>
 
 #include <velodyne_pointcloud/rawdata.h>
 
-namespace velodyne_rawdata {
-////////////////////////////////////////////////////////////////////////
-//
-// RawData base class implementation
-//
-////////////////////////////////////////////////////////////////////////
-
-RawData::RawData()
+namespace velodyne_rawdata
 {
-}
+  ////////////////////////////////////////////////////////////////////////
+  //
+  // RawData base class implementation
+  //
+  ////////////////////////////////////////////////////////////////////////
 
-/** Update parameters: conversions and update */
-void RawData::setParameters(double min_range, double max_range, double view_direction,
-                            double view_width)
-{
-  config_.min_range = min_range;
-  config_.max_range = max_range;
+  RawData::RawData() {}
+  
+  /** Update parameters: conversions and update */
+  void RawData::setParameters(double min_range,
+                              double max_range,
+                              double view_direction,
+                              double view_width)
+  {
+    config_.min_range = min_range;
+    config_.max_range = max_range;
 
-  // converting angle parameters into the velodyne reference (rad)
-  config_.tmp_min_angle = view_direction + view_width / 2;
-  config_.tmp_max_angle = view_direction - view_width / 2;
-
-  // computing positive modulo to keep theses angles into [0;2*M_PI]
-  config_.tmp_min_angle = fmod(fmod(config_.tmp_min_angle, 2 * M_PI) + 2 * M_PI, 2 * M_PI);
-  config_.tmp_max_angle = fmod(fmod(config_.tmp_max_angle, 2 * M_PI) + 2 * M_PI, 2 * M_PI);
-
-  // converting into the hardware velodyne ref (negative yaml and degrees)
-  // adding 0.5 perfomrs a centered double to int conversion
-  config_.min_angle = 100 * (2 * M_PI - config_.tmp_min_angle) * 180 / M_PI + 0.5;
-  config_.max_angle = 100 * (2 * M_PI - config_.tmp_max_angle) * 180 / M_PI + 0.5;
-  if (config_.min_angle == config_.max_angle) {
-    // avoid returning empty cloud if min_angle = max_angle
-    config_.min_angle = 0;
-    config_.max_angle = 36000;
-  }
-}
-
-/** Set up for on-line operation. */
-int RawData::setup(ros::NodeHandle private_nh)
-{
-  // get path to angles.config file for this device
-  if (!private_nh.getParam("calibration", config_.calibrationFile)) {
-    ROS_ERROR_STREAM("No calibration angles specified! Using test values!");
-
-    // have to use something: grab unit test version as a default
-    std::string pkgPath = ros::package::getPath("velodyne_pointcloud");
-    config_.calibrationFile = pkgPath + "/params/64e_utexas.yaml";
-  }
-
-  ROS_INFO_STREAM("correction angles: " << config_.calibrationFile);
-
-  calibration_.read(config_.calibrationFile);
-  if (!calibration_.initialized) {
-    ROS_ERROR_STREAM("Unable to open calibration file: " << config_.calibrationFile);
-    return -1;
-  }
-
-  ROS_INFO_STREAM("Number of lasers: " << calibration_.num_lasers << ".");
-
-  if (!private_nh.getParam("device_model", config_.deviceModel)) {
-    ROS_WARN_STREAM("device_model not specified");
-  }
-
-  if (calibration_.num_lasers == 16) {
-    vlp_spec_ = VLP_16_SPEC;
-    is_vlp_ = true;
-  } else if (config_.deviceModel == "VLP32") {
-    vlp_spec_ = VLP_32_SPEC;
-    is_vlp_ = true;
-    // Print corrections
-    std::vector<float> elev_spec = {
-      -25.0,  -1.0,   -1.667, -15.639, -11.31, 0.0,    -0.667, -8.843, -7.254, 0.333,  -0.333,
-      -6.148, -5.333, 1.333,  0.667,   -4.0,   -4.667, 1.667,  1.0,    -3.667, -3.333, 3.333,
-      2.333,  -2.667, -3.0,   7.0,     4.667,  -2.333, -2.0,   15.0,   10.333, -1.333
-    };
-    std::vector<float> az_spec = { 1.4,  -4.2, 1.4,  -1.4, 1.4,  -1.4, 4.2,  -1.4, 1.4,  -4.2, 1.4,
-                                   -1.4, 4.2,  -1.4, 4.2,  -1.4, 1.4,  -4.2, 1.4,  -4.2, 4.2,  -1.4,
-                                   1.4,  -1.4, 1.4,  -1.4, 1.4,  -4.2, 4.2,  -1.4, 1.4,  -1.4 };
-    for (int i = 0; i < 32; ++i) {
-      std::printf("Laser: %d Elevation angle: %.3f, spec: %.3f. Azimuth offset: %.3f, spec: %.3f\n",
-                  i, 180. / M_PI * std::asin(calibration_.laser_corrections[i].sin_vert_correction),
-                  elev_spec[i],
-                  180. / M_PI * std::asin(calibration_.laser_corrections[i].sin_rot_correction),
-                  az_spec[i]);
+    //converting angle parameters into the velodyne reference (rad)
+    config_.tmp_min_angle = view_direction + view_width/2;
+    config_.tmp_max_angle = view_direction - view_width/2;
+    
+    //computing positive modulo to keep theses angles into [0;2*M_PI]
+    config_.tmp_min_angle = fmod(fmod(config_.tmp_min_angle,2*M_PI) + 2*M_PI,2*M_PI);
+    config_.tmp_max_angle = fmod(fmod(config_.tmp_max_angle,2*M_PI) + 2*M_PI,2*M_PI);
+    
+    //converting into the hardware velodyne ref (negative yaml and degrees)
+    //adding 0.5 perfomrs a centered double to int conversion 
+    config_.min_angle = 100 * (2*M_PI - config_.tmp_min_angle) * 180 / M_PI + 0.5;
+    config_.max_angle = 100 * (2*M_PI - config_.tmp_max_angle) * 180 / M_PI + 0.5;
+    if (config_.min_angle == config_.max_angle)
+    {
+      //avoid returning empty cloud if min_angle = max_angle
+      config_.min_angle = 0;
+      config_.max_angle = 36000;
     }
-    // The calibration file has negative angles for azimuth correction -> w/o that output is crap...
-  } else {
-    is_vlp_ = false;
   }
 
-  // Set up cached values for sin and cos of all the possible headings
-  for (uint16_t rot_index = 0; rot_index < ROTATION_MAX_UNITS; ++rot_index) {
-    float rotation = angles::from_degrees(ROTATION_RESOLUTION * rot_index);
-    cos_rot_table_[rot_index] = cosf(rotation);
-    sin_rot_table_[rot_index] = sinf(rotation);
-  }
-  return 0;
-}
+  /** Set up for on-line operation. */
+  int RawData::setup(ros::NodeHandle private_nh)
+  {
+    // get path to angles.config file for this device
+    if (!private_nh.getParam("calibration", config_.calibrationFile))
+      {
+        ROS_ERROR_STREAM("No calibration angles specified! Using test values!");
 
-/** @brief convert raw packet to point cloud
- *
- *  @param pkt raw packet to unpack
- *  @param pc shared pointer to point cloud (points are appended)
- */
-float RawData::unpackAndAdd(const velodyne_msgs::VelodynePacket& pkt, VPointCloud& pc, size_t* valid_pnts) const
-{
-  ROS_DEBUG_STREAM("Received packet, time: " << pkt.stamp);
-
-  /** special parsing for the VLP16 and VLP32 **/
-  if (is_vlp_) {
-    return unpack_vlp(pkt, pc, valid_pnts);
-  }
-
-  const raw_packet_t* raw = (const raw_packet_t*)&pkt.data[0];
-
-  for (int i = 0; i < BLOCKS_PER_PACKET; i++) {
-    // upper bank lasers are numbered [0..31]
-    // NOTE: this is a change from the old velodyne_common implementation
-    int bank_origin = 0;
-    if (raw->blocks[i].header == LOWER_BANK) {
-      // lower bank lasers are [32..63]
-      bank_origin = 32;
-    }
-
-    for (int j = 0, k = 0; j < SCANS_PER_BLOCK; j++, k += RAW_SCAN_SIZE) {
-      float x, y, z;
-      float intensity;
-      uint8_t laser_number; ///< hardware laser number
-
-      laser_number = j + bank_origin;
-      const velodyne_pointcloud::LaserCorrection& corrections =
-          calibration_.laser_corrections.at(laser_number);
-
-      /** Position Calculation */
-
-      union two_bytes tmp;
-      tmp.bytes[0] = raw->blocks[i].data[k];
-      tmp.bytes[1] = raw->blocks[i].data[k + 1];
-      /*condition added to avoid calculating points which are not
-        in the interesting defined area (min_angle < area < max_angle)*/
-      if ((raw->blocks[i].rotation >= config_.min_angle &&
-           raw->blocks[i].rotation <= config_.max_angle && config_.min_angle < config_.max_angle) ||
-          (config_.min_angle > config_.max_angle &&
-           (raw->blocks[i].rotation <= config_.max_angle ||
-            raw->blocks[i].rotation >= config_.min_angle))) {
-        float distance = tmp.uint * DISTANCE_RESOLUTION;
-        distance += corrections.dist_correction;
-
-        float cos_vert_angle = corrections.cos_vert_correction;
-        float sin_vert_angle = corrections.sin_vert_correction;
-        float cos_rot_correction = corrections.cos_rot_correction;
-        float sin_rot_correction = corrections.sin_rot_correction;
-
-        // cos(a-b) = cos(a)*cos(b) + sin(a)*sin(b)
-        // sin(a-b) = sin(a)*cos(b) - cos(a)*sin(b)
-        float cos_rot_angle = cos_rot_table_[raw->blocks[i].rotation] * cos_rot_correction +
-                              sin_rot_table_[raw->blocks[i].rotation] * sin_rot_correction;
-        float sin_rot_angle = sin_rot_table_[raw->blocks[i].rotation] * cos_rot_correction -
-                              cos_rot_table_[raw->blocks[i].rotation] * sin_rot_correction;
-
-        float horiz_offset = corrections.horiz_offset_correction;
-        float vert_offset = corrections.vert_offset_correction;
-
-        // Compute the distance in the xy plane (w/o accounting for rotation)
-        /**the new term of 'vert_offset * sin_vert_angle'
-         * was added to the expression due to the mathemathical
-         * model we used.
-         */
-        float xy_distance = distance * cos_vert_angle - vert_offset * sin_vert_angle;
-
-        // Calculate temporal X, use absolute value.
-        float xx = xy_distance * sin_rot_angle - horiz_offset * cos_rot_angle;
-        // Calculate temporal Y, use absolute value
-        float yy = xy_distance * cos_rot_angle + horiz_offset * sin_rot_angle;
-        if (xx < 0)
-          xx = -xx;
-        if (yy < 0)
-          yy = -yy;
-
-        // Get 2points calibration values,Linear interpolation to get distance
-        // correction for X and Y, that means distance correction use
-        // different value at different distance
-        float distance_corr_x = 0;
-        float distance_corr_y = 0;
-        if (corrections.two_pt_correction_available) {
-          distance_corr_x = (corrections.dist_correction - corrections.dist_correction_x) *
-                                (xx - 2.4) / (25.04 - 2.4) +
-                            corrections.dist_correction_x;
-          distance_corr_x -= corrections.dist_correction;
-          distance_corr_y = (corrections.dist_correction - corrections.dist_correction_y) *
-                                (yy - 1.93) / (25.04 - 1.93) +
-                            corrections.dist_correction_y;
-          distance_corr_y -= corrections.dist_correction;
-        }
-
-        float distance_x = distance + distance_corr_x;
-        /**the new term of 'vert_offset * sin_vert_angle'
-         * was added to the expression due to the mathemathical
-         * model we used.
-         */
-        xy_distance = distance_x * cos_vert_angle - vert_offset * sin_vert_angle;
-        /// the expression wiht '-' is proved to be better than the one with '+'
-        x = xy_distance * sin_rot_angle - horiz_offset * cos_rot_angle;
-
-        float distance_y = distance + distance_corr_y;
-        xy_distance = distance_y * cos_vert_angle - vert_offset * sin_vert_angle;
-        /**the new term of 'vert_offset * sin_vert_angle'
-         * was added to the expression due to the mathemathical
-         * model we used.
-         */
-        y = xy_distance * cos_rot_angle + horiz_offset * sin_rot_angle;
-
-        // Using distance_y is not symmetric, but the velodyne manual
-        // does this.
-        /**the new term of 'vert_offset * cos_vert_angle'
-         * was added to the expression due to the mathemathical
-         * model we used.
-         */
-        z = distance_y * sin_vert_angle + vert_offset * cos_vert_angle;
-
-        /** Use standard ROS coordinate system (right-hand rule) */
-        float x_coord = y;
-        float y_coord = -x;
-        float z_coord = z;
-
-        /** Intensity Calculation */
-
-        float min_intensity = corrections.min_intensity;
-        float max_intensity = corrections.max_intensity;
-
-        intensity = raw->blocks[i].data[k + 2];
-
-        float focal_offset = 256 * (1 - corrections.focal_distance / 13100) *
-                             (1 - corrections.focal_distance / 13100);
-        float focal_slope = corrections.focal_slope;
-        intensity += focal_slope * (abs(focal_offset -
-                                        256 * (1 - static_cast<float>(tmp.uint) / 65535) *
-                                            (1 - static_cast<float>(tmp.uint) / 65535)));
-        intensity = (intensity < min_intensity) ? min_intensity : intensity;
-        intensity = (intensity > max_intensity) ? max_intensity : intensity;
-
-        if (pointInRange(distance)) {
-          // convert polar coordinates to Euclidean XYZ
-          VPoint point;
-          point.ring = corrections.laser_ring;
-          point.x = x_coord;
-          point.y = y_coord;
-          point.z = z_coord;
-          point.intensity = intensity;
-
-          // append this point to the cloud
-          pc.points.push_back(point);
-          ++pc.width;
-        }
+        // have to use something: grab unit test version as a default
+        std::string pkgPath = ros::package::getPath("velodyne_pointcloud");
+        config_.calibrationFile = pkgPath + "/params/64e_utexas.yaml";
       }
+
+    ROS_INFO_STREAM("correction angles: " << config_.calibrationFile);
+
+    calibration_.read(config_.calibrationFile);
+    if (!calibration_.initialized) {
+      ROS_ERROR_STREAM("Unable to open calibration file: " << 
+          config_.calibrationFile);
+      return -1;
     }
-  }
-  return -1.0;
-}
+    
+    ROS_INFO_STREAM("Number of lasers: " << calibration_.num_lasers << ".");
 
-/** @brief convert raw VLP16 and VLP32 packet to point cloud
- *
- *  @param pkt raw packet to unpack
- *  @param pc shared pointer to point cloud (points are appended)
- */
-float RawData::unpack_vlp(const velodyne_msgs::VelodynePacket& pkt, VPointCloud& pc,
-                          size_t* valid_pnts) const
-{
-  float azimuth;
-  float azimuth_diff;
-  float last_azimuth_diff = 0;
-  float azimuth_corrected_f;
-  int azimuth_corrected;
-  float x, y, z;
-  float intensity;
-  float slice_angle = 0.0;
-
-  if (vlp_spec_.lasers_per_firing_seq == 32) {
-    ROS_INFO_THROTTLE(60, "Unpacking VLP32");
-    assert(vlp_spec_.firing_seqs_per_block == 1);
-  } else {
-    ROS_INFO_THROTTLE(60, "Unpacking VLP16");
-  }
-
-  const raw_packet_t* raw = (const raw_packet_t*)&pkt.data[0];
-
-  ROS_INFO_THROTTLE(60, "Return Mode: 0x%X, Product ID: 0x%X", pkt.data[1204], pkt.data[1205]);
-
-  std::set<std::tuple<float, float, float>> pnts_set; // expensive -- just bug-hunting!!!
-  size_t duplicates = 0;
-  size_t num_ok = 0;
-  size_t num_filtered_azimuth = 0;
-  size_t num_filtered_range = 0;
-
-  for (int block = 0; block < BLOCKS_PER_PACKET; block++) {
-    // Each block has 2b flag, 2b az, 32*(2b dist, 1b reflectivity)
-
-    // ignore packets with mangled or otherwise different contents
-    if (UPPER_BANK != raw->blocks[block].header) { // b 0,1
-      // Do not flood the log with messages, only issue at most one
-      // of these warnings per minute.
-      ROS_WARN_STREAM_THROTTLE(60, "skipping invalid VLP packet: block "
-                                       << block << " header value is "
-                                       << raw->blocks[block].header);
-      return -1; // bad packet: skip the rest
+    if (!private_nh.getParam("device_model", config_.deviceModel)) {
+      ROS_WARN_STREAM("device_model not specified");
     }
 
-    // Calculate difference between current and next block's azimuth angle.
-    azimuth = (float)(raw->blocks[block].rotation); // b 2,3
-
-    if (block < (BLOCKS_PER_PACKET - 1)) {
-      azimuth_diff =
-          (float)((36000 + raw->blocks[block + 1].rotation - raw->blocks[block].rotation) % 36000);
-      slice_angle += azimuth_diff;
-      last_azimuth_diff = azimuth_diff;
+    if (calibration_.num_lasers == 16) {
+      vlp_spec_ = VLP_16_SPEC;
+      is_vlp_ = true;
+    } else if (config_.deviceModel == "VLP32") {
+      vlp_spec_ = VLP_32_SPEC;
+      is_vlp_ = true;
     } else {
-      azimuth_diff = last_azimuth_diff;
+      is_vlp_ = false;
     }
 
-    /* configuration for VLP32C:
+    // Set up cached values for sin and cos of all the possible headings
+    for (uint16_t rot_index = 0; rot_index < ROTATION_MAX_UNITS; ++rot_index) {
+      float rotation = angles::from_degrees(ROTATION_RESOLUTION * rot_index);
+      cos_rot_table_[rot_index] = cosf(rotation);
+      sin_rot_table_[rot_index] = sinf(rotation);
+    }
+   return 0;
+  }
 
-       firing_seqs_per_block = 1
-       lasers_per_firing_seq = 32
-       lasers_per_firing     = 2
-       firing_duration;      = 2.304  [us]
-       firing_seq_duration   = 55.296 [us]
-       block_duration        = 55.296 [us] = firing_seq_duration * firing_seqs_per_block
-       distance_resolution   = 0.004  [m]
+  /** @brief convert raw packet to point cloud
+   *
+   *  @param pkt raw packet to unpack
+   *  @param pc shared pointer to point cloud (points are appended)
+   */
+  float RawData::unpack(const velodyne_msgs::VelodynePacket &pkt,
+                       VPointCloud &pc)
+  {
+    ROS_DEBUG_STREAM("Received packet, time: " << pkt.stamp);
+    
+    /** special parsing for the VLP16 and VLP32 **/
+    if (is_vlp_)
+    {
+      return unpack_vlp(pkt, pc);
+    }
+    
+    const raw_packet_t *raw = (const raw_packet_t *) &pkt.data[0];
 
-       RAW_SCAN_SIZE = 3 (bytes)
-    */
-    // Go trough the 32, 3 byte laser hits
-    for (int firing_seq = 0, k = 0; firing_seq < vlp_spec_.firing_seqs_per_block; firing_seq++) {
-      for (int laser = 0; laser < vlp_spec_.lasers_per_firing_seq; laser++, k += RAW_SCAN_SIZE) {
-        const velodyne_pointcloud::LaserCorrection& corrections = calibration_.laser_corrections.at(laser);
+    for (int i = 0; i < BLOCKS_PER_PACKET; i++) {
+
+      // upper bank lasers are numbered [0..31]
+      // NOTE: this is a change from the old velodyne_common implementation
+      int bank_origin = 0;
+      if (raw->blocks[i].header == LOWER_BANK) {
+        // lower bank lasers are [32..63]
+        bank_origin = 32;
+      }
+
+      for (int j = 0, k = 0; j < SCANS_PER_BLOCK; j++, k += RAW_SCAN_SIZE) {
+        
+        float x, y, z;
+        float intensity;
+        uint8_t laser_number;       ///< hardware laser number
+
+        laser_number = j + bank_origin;
+        velodyne_pointcloud::LaserCorrection &corrections = 
+          calibration_.laser_corrections[laser_number];
 
         /** Position Calculation */
+
         union two_bytes tmp;
-        tmp.bytes[0] = raw->blocks[block].data[k];
-        tmp.bytes[1] = raw->blocks[block].data[k + 1];
-
-        /** correct for the laser rotation as a function of timing during the firings **/
-        float firing_offset = (laser / vlp_spec_.lasers_per_firing) * vlp_spec_.firing_duration;
-        float firing_seq_offset = firing_seq * vlp_spec_.firing_seq_duration;
-        azimuth_corrected_f = azimuth + (azimuth_diff * (firing_offset + firing_seq_offset) /
-                                         vlp_spec_.block_duration);
-        azimuth_corrected = ((int)round(azimuth_corrected_f)) % 36000;
-
+        tmp.bytes[0] = raw->blocks[i].data[k];
+        tmp.bytes[1] = raw->blocks[i].data[k+1];
         /*condition added to avoid calculating points which are not
           in the interesting defined area (min_angle < area < max_angle)*/
-        if ((azimuth_corrected >= config_.min_angle && azimuth_corrected <= config_.max_angle &&
-             config_.min_angle < config_.max_angle) ||
-            (config_.min_angle > config_.max_angle &&
-             (azimuth_corrected <= config_.max_angle || azimuth_corrected >= config_.min_angle))) {
-          // convert polar coordinates to Euclidean XYZ
-          float distance = tmp.uint * vlp_spec_.distance_resolution;
+        if ((raw->blocks[i].rotation >= config_.min_angle 
+             && raw->blocks[i].rotation <= config_.max_angle 
+             && config_.min_angle < config_.max_angle)
+             ||(config_.min_angle > config_.max_angle 
+             && (raw->blocks[i].rotation <= config_.max_angle 
+             || raw->blocks[i].rotation >= config_.min_angle))){
+          float distance = tmp.uint * DISTANCE_RESOLUTION;
           distance += corrections.dist_correction;
-
+  
           float cos_vert_angle = corrections.cos_vert_correction;
           float sin_vert_angle = corrections.sin_vert_correction;
           float cos_rot_correction = corrections.cos_rot_correction;
           float sin_rot_correction = corrections.sin_rot_correction;
-
+  
           // cos(a-b) = cos(a)*cos(b) + sin(a)*sin(b)
           // sin(a-b) = sin(a)*cos(b) - cos(a)*sin(b)
-          float cos_rot_angle = cos_rot_table_[azimuth_corrected] * cos_rot_correction +
-                                sin_rot_table_[azimuth_corrected] * sin_rot_correction;
-          float sin_rot_angle = sin_rot_table_[azimuth_corrected] * cos_rot_correction -
-                                cos_rot_table_[azimuth_corrected] * sin_rot_correction;
-
+          float cos_rot_angle = 
+            cos_rot_table_[raw->blocks[i].rotation] * cos_rot_correction + 
+            sin_rot_table_[raw->blocks[i].rotation] * sin_rot_correction;
+          float sin_rot_angle = 
+            sin_rot_table_[raw->blocks[i].rotation] * cos_rot_correction - 
+            cos_rot_table_[raw->blocks[i].rotation] * sin_rot_correction;
+  
           float horiz_offset = corrections.horiz_offset_correction;
           float vert_offset = corrections.vert_offset_correction;
-
+  
           // Compute the distance in the xy plane (w/o accounting for rotation)
           /**the new term of 'vert_offset * sin_vert_angle'
            * was added to the expression due to the mathemathical
            * model we used.
            */
           float xy_distance = distance * cos_vert_angle - vert_offset * sin_vert_angle;
-
+  
           // Calculate temporal X, use absolute value.
           float xx = xy_distance * sin_rot_angle - horiz_offset * cos_rot_angle;
           // Calculate temporal Y, use absolute value
           float yy = xy_distance * cos_rot_angle + horiz_offset * sin_rot_angle;
-          if (xx < 0)
-            xx = -xx;
-          if (yy < 0)
-            yy = -yy;
-
+          if (xx < 0) xx=-xx;
+          if (yy < 0) yy=-yy;
+    
           // Get 2points calibration values,Linear interpolation to get distance
           // correction for X and Y, that means distance correction use
           // different value at different distance
           float distance_corr_x = 0;
           float distance_corr_y = 0;
           if (corrections.two_pt_correction_available) {
-            distance_corr_x = (corrections.dist_correction - corrections.dist_correction_x) *
-                                  (xx - 2.4) / (25.04 - 2.4) +
-                              corrections.dist_correction_x;
+            distance_corr_x = 
+              (corrections.dist_correction - corrections.dist_correction_x)
+                * (xx - 2.4) / (25.04 - 2.4) 
+              + corrections.dist_correction_x;
             distance_corr_x -= corrections.dist_correction;
-            distance_corr_y = (corrections.dist_correction - corrections.dist_correction_y) *
-                                  (yy - 1.93) / (25.04 - 1.93) +
-                              corrections.dist_correction_y;
+            distance_corr_y = 
+              (corrections.dist_correction - corrections.dist_correction_y)
+                * (yy - 1.93) / (25.04 - 1.93)
+              + corrections.dist_correction_y;
             distance_corr_y -= corrections.dist_correction;
           }
-
+  
           float distance_x = distance + distance_corr_x;
           /**the new term of 'vert_offset * sin_vert_angle'
            * was added to the expression due to the mathemathical
            * model we used.
            */
-          xy_distance = distance_x * cos_vert_angle - vert_offset * sin_vert_angle;
+          xy_distance = distance_x * cos_vert_angle - vert_offset * sin_vert_angle ;
+          ///the expression wiht '-' is proved to be better than the one with '+'
           x = xy_distance * sin_rot_angle - horiz_offset * cos_rot_angle;
-
+  
           float distance_y = distance + distance_corr_y;
+          xy_distance = distance_y * cos_vert_angle - vert_offset * sin_vert_angle ;
           /**the new term of 'vert_offset * sin_vert_angle'
            * was added to the expression due to the mathemathical
            * model we used.
            */
-          xy_distance = distance_y * cos_vert_angle - vert_offset * sin_vert_angle;
           y = xy_distance * cos_rot_angle + horiz_offset * sin_rot_angle;
-
+  
           // Using distance_y is not symmetric, but the velodyne manual
           // does this.
           /**the new term of 'vert_offset * cos_vert_angle'
            * was added to the expression due to the mathemathical
            * model we used.
            */
-          z = distance_y * sin_vert_angle + vert_offset * cos_vert_angle;
-
-
+          z = distance_y * sin_vert_angle + vert_offset*cos_vert_angle;
+  
           /** Use standard ROS coordinate system (right-hand rule) */
           float x_coord = y;
           float y_coord = -x;
           float z_coord = z;
-
+  
           /** Intensity Calculation */
+  
           float min_intensity = corrections.min_intensity;
           float max_intensity = corrections.max_intensity;
-
-          intensity = raw->blocks[block].data[k + 2];
-
-          float focal_offset = 256 * (1 - corrections.focal_distance / 13100) *
-                               (1 - corrections.focal_distance / 13100);
+  
+          intensity = raw->blocks[i].data[k+2];
+  
+          float focal_offset = 256 
+                             * (1 - corrections.focal_distance / 13100) 
+                             * (1 - corrections.focal_distance / 13100);
           float focal_slope = corrections.focal_slope;
-          intensity += focal_slope *
-                       (abs(focal_offset - 256 * (1 - tmp.uint / 65535) * (1 - tmp.uint / 65535)));
+          intensity += focal_slope * (abs(focal_offset - 256 * 
+            (1 - static_cast<float>(tmp.uint)/65535)*(1 - static_cast<float>(tmp.uint)/65535)));
           intensity = (intensity < min_intensity) ? min_intensity : intensity;
           intensity = (intensity > max_intensity) ? max_intensity : intensity;
-
+  
           if (pointInRange(distance)) {
-            // append this point to the cloud
+  
+            // convert polar coordinates to Euclidean XYZ
             VPoint point;
             point.ring = corrections.laser_ring;
             point.x = x_coord;
             point.y = y_coord;
             point.z = z_coord;
             point.intensity = intensity;
-
-            auto pnt_tuple = std::make_tuple(point.x, point.y, point.z);
-            if (pnts_set.count(pnt_tuple) == 0) {
-              pnts_set.insert(pnt_tuple);
-            } else {
-              duplicates++;
-            }
-
-            num_ok++;
+  
+            // append this point to the cloud
             pc.points.push_back(point);
             ++pc.width;
-          } else {
-            num_filtered_range++;
           }
-        } else {
-          num_filtered_azimuth++;
         }
-      } // end for laser
-    }   // end for firing_seq
-  }     // end for block
-
-  if (valid_pnts != nullptr) {
-    *valid_pnts = num_ok;
+      }
+    }
+    return -1.0;
   }
-  //  std::printf("%lu OK pnts in PKT, filtered: AZ: %lu RNG: %lu, duplicates: %lu, total=%lu, "
-  //              "slice now has %lu pnts\n",
-  //              num_ok, num_filtered_azimuth, num_filtered_range, duplicates,
-  //              num_ok + num_filtered_azimuth + num_filtered_range, pc.points.size());
-  return slice_angle;
-}
+  
+  /** @brief convert raw VLP16 and VLP32 packet to point cloud
+   *
+   *  @param pkt raw packet to unpack
+   *  @param pc shared pointer to point cloud (points are appended)
+   */
+  float RawData::unpack_vlp(const velodyne_msgs::VelodynePacket &pkt,
+                             VPointCloud &pc)
+  {
+    float azimuth;
+    float azimuth_diff;
+    float last_azimuth_diff=0;
+    float azimuth_corrected_f;
+    int azimuth_corrected;
+    float x, y, z;
+    float intensity;
+    float slice_angle = 0.0;
+
+    const raw_packet_t *raw = (const raw_packet_t *) &pkt.data[0];
+
+    for (int block = 0; block < BLOCKS_PER_PACKET; block++) {
+
+      // ignore packets with mangled or otherwise different contents
+      if (UPPER_BANK != raw->blocks[block].header) {
+        // Do not flood the log with messages, only issue at most one
+        // of these warnings per minute.
+        ROS_WARN_STREAM_THROTTLE(60, "skipping invalid VLP packet: block "
+                                 << block << " header value is "
+                                 << raw->blocks[block].header);
+        return -1;                         // bad packet: skip the rest
+      }
+
+      // Calculate difference between current and next block's azimuth angle.
+      azimuth = (float)(raw->blocks[block].rotation);
+
+      //Debug 
+      //std::cout << "Block: " << block << ", Azimuth: " << azimuth << std::endl;
+
+      if (block < (BLOCKS_PER_PACKET-1)){
+        azimuth_diff = (float)((36000 + raw->blocks[block+1].rotation - raw->blocks[block].rotation)%36000);
+        slice_angle += azimuth_diff;
+        last_azimuth_diff = azimuth_diff;
+      }else{
+        azimuth_diff = last_azimuth_diff;
+      }
+
+      for (int firing_seq=0, k=0; firing_seq < vlp_spec_.firing_seqs_per_block; firing_seq++){
+        for (int laser=0; laser < vlp_spec_.lasers_per_firing_seq; laser++, k+=RAW_SCAN_SIZE){
+          velodyne_pointcloud::LaserCorrection &corrections = 
+            calibration_.laser_corrections[laser];
+
+          /** Position Calculation */
+          union two_bytes tmp;
+          tmp.bytes[0] = raw->blocks[block].data[k];
+          tmp.bytes[1] = raw->blocks[block].data[k+1];
+          
+          /** correct for the laser rotation as a function of timing during the firings **/
+          float firing_offset = (laser / vlp_spec_.lasers_per_firing) * vlp_spec_.firing_duration;
+          float firing_seq_offset = firing_seq * vlp_spec_.firing_seq_duration;
+          azimuth_corrected_f = azimuth + (azimuth_diff * (firing_offset + firing_seq_offset) / vlp_spec_.block_duration);
+          azimuth_corrected = ((int)round(azimuth_corrected_f)) % 36000;
+          
+          /*condition added to avoid calculating points which are not
+            in the interesting defined area (min_angle < area < max_angle)*/
+          if ((azimuth_corrected >= config_.min_angle 
+               && azimuth_corrected <= config_.max_angle 
+               && config_.min_angle < config_.max_angle)
+               ||(config_.min_angle > config_.max_angle 
+               && (azimuth_corrected <= config_.max_angle 
+               || azimuth_corrected >= config_.min_angle))){
+
+            // convert polar coordinates to Euclidean XYZ
+            float distance = tmp.uint * vlp_spec_.distance_resolution;
+            distance += corrections.dist_correction;
+            
+            float cos_vert_angle = corrections.cos_vert_correction;
+            float sin_vert_angle = corrections.sin_vert_correction;
+            float cos_rot_correction = corrections.cos_rot_correction;
+            float sin_rot_correction = corrections.sin_rot_correction;
+    
+            // cos(a-b) = cos(a)*cos(b) + sin(a)*sin(b)
+            // sin(a-b) = sin(a)*cos(b) - cos(a)*sin(b)
+            float cos_rot_angle = 
+              cos_rot_table_[azimuth_corrected] * cos_rot_correction + 
+              sin_rot_table_[azimuth_corrected] * sin_rot_correction;
+            float sin_rot_angle = 
+              sin_rot_table_[azimuth_corrected] * cos_rot_correction - 
+              cos_rot_table_[azimuth_corrected] * sin_rot_correction;
+    
+            float horiz_offset = corrections.horiz_offset_correction;
+            float vert_offset = corrections.vert_offset_correction;
+    
+            // Compute the distance in the xy plane (w/o accounting for rotation)
+            /**the new term of 'vert_offset * sin_vert_angle'
+             * was added to the expression due to the mathemathical
+             * model we used.
+             */
+            float xy_distance = distance * cos_vert_angle - vert_offset * sin_vert_angle;
+    
+            // Calculate temporal X, use absolute value.
+            float xx = xy_distance * sin_rot_angle - horiz_offset * cos_rot_angle;
+            // Calculate temporal Y, use absolute value
+            float yy = xy_distance * cos_rot_angle + horiz_offset * sin_rot_angle;
+            if (xx < 0) xx=-xx;
+            if (yy < 0) yy=-yy;
+      
+            // Get 2points calibration values,Linear interpolation to get distance
+            // correction for X and Y, that means distance correction use
+            // different value at different distance
+            float distance_corr_x = 0;
+            float distance_corr_y = 0;
+            if (corrections.two_pt_correction_available) {
+              distance_corr_x = 
+                (corrections.dist_correction - corrections.dist_correction_x)
+                  * (xx - 2.4) / (25.04 - 2.4) 
+                + corrections.dist_correction_x;
+              distance_corr_x -= corrections.dist_correction;
+              distance_corr_y = 
+                (corrections.dist_correction - corrections.dist_correction_y)
+                  * (yy - 1.93) / (25.04 - 1.93)
+                + corrections.dist_correction_y;
+              distance_corr_y -= corrections.dist_correction;
+            }
+    
+            float distance_x = distance + distance_corr_x;
+            /**the new term of 'vert_offset * sin_vert_angle'
+             * was added to the expression due to the mathemathical
+             * model we used.
+             */
+            xy_distance = distance_x * cos_vert_angle - vert_offset * sin_vert_angle ;
+            x = xy_distance * sin_rot_angle - horiz_offset * cos_rot_angle;
+    
+            float distance_y = distance + distance_corr_y;
+            /**the new term of 'vert_offset * sin_vert_angle'
+             * was added to the expression due to the mathemathical
+             * model we used.
+             */
+            xy_distance = distance_y * cos_vert_angle - vert_offset * sin_vert_angle ;
+            y = xy_distance * cos_rot_angle + horiz_offset * sin_rot_angle;
+    
+            // Using distance_y is not symmetric, but the velodyne manual
+            // does this.
+            /**the new term of 'vert_offset * cos_vert_angle'
+             * was added to the expression due to the mathemathical
+             * model we used.
+             */
+            z = distance_y * sin_vert_angle + vert_offset*cos_vert_angle;
+  
+    
+            /** Use standard ROS coordinate system (right-hand rule) */
+            float x_coord = y;
+            float y_coord = -x;
+            float z_coord = z;
+    
+            /** Intensity Calculation */
+            float min_intensity = corrections.min_intensity;
+            float max_intensity = corrections.max_intensity;
+    
+            intensity = raw->blocks[block].data[k+2];
+    
+            float focal_offset = 256 
+                               * (1 - corrections.focal_distance / 13100) 
+                               * (1 - corrections.focal_distance / 13100);
+            float focal_slope = corrections.focal_slope;
+            intensity += focal_slope * (abs(focal_offset - 256 * 
+              (1 - tmp.uint/65535)*(1 - tmp.uint/65535)));
+            intensity = (intensity < min_intensity) ? min_intensity : intensity;
+            intensity = (intensity > max_intensity) ? max_intensity : intensity;
+    
+            if (pointInRange(distance)) {
+    
+              // append this point to the cloud
+              VPoint point;
+              point.ring = corrections.laser_ring;
+              point.x = x_coord;
+              point.y = y_coord;
+              point.z = z_coord;
+              point.intensity = intensity;
+
+              pc.points.push_back(point);
+              ++pc.width;
+            }
+          }
+        }
+      }
+    }
+    return slice_angle;
+  }  
 
 } // namespace velodyne_rawdata

--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -125,7 +125,7 @@ namespace velodyne_rawdata
    *  @param pkt raw packet to unpack
    *  @param pc shared pointer to point cloud (points are appended)
    */
-  float RawData::unpack(const velodyne_msgs::VelodynePacket &pkt,
+  float RawData::unpackAndAdd(const velodyne_msgs::VelodynePacket &pkt,
                        VPointCloud &pc)
   {
     ROS_DEBUG_STREAM("Received packet, time: " << pkt.stamp);

--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -138,7 +138,7 @@ int RawData::setup(ros::NodeHandle private_nh)
  *  @param pkt raw packet to unpack
  *  @param pc shared pointer to point cloud (points are appended)
  */
-float RawData::unpack(const velodyne_msgs::VelodynePacket& pkt, VPointCloud& pc, size_t* valid_pnts) const
+float RawData::unpackAndAdd(const velodyne_msgs::VelodynePacket& pkt, VPointCloud& pc, size_t* valid_pnts) const
 {
   ROS_DEBUG_STREAM("Received packet, time: " << pkt.stamp);
 

--- a/velodyne_pointcloud/src/lib/rawdata.cc
+++ b/velodyne_pointcloud/src/lib/rawdata.cc
@@ -25,456 +25,501 @@
  *  HDL-64E S2 calibration support provided by Nick Hillier
  */
 
-#include <fstream>
 #include <math.h>
+#include <fstream>
 
-#include <ros/ros.h>
-#include <ros/package.h>
 #include <angles/angles.h>
+#include <ros/package.h>
+#include <ros/ros.h>
 
 #include <velodyne_pointcloud/rawdata.h>
 
-namespace velodyne_rawdata
+namespace velodyne_rawdata {
+////////////////////////////////////////////////////////////////////////
+//
+// RawData base class implementation
+//
+////////////////////////////////////////////////////////////////////////
+
+RawData::RawData()
 {
-  ////////////////////////////////////////////////////////////////////////
-  //
-  // RawData base class implementation
-  //
-  ////////////////////////////////////////////////////////////////////////
+}
 
-  RawData::RawData() {}
-  
-  /** Update parameters: conversions and update */
-  void RawData::setParameters(double min_range,
-                              double max_range,
-                              double view_direction,
-                              double view_width)
-  {
-    config_.min_range = min_range;
-    config_.max_range = max_range;
+/** Update parameters: conversions and update */
+void RawData::setParameters(double min_range, double max_range, double view_direction,
+                            double view_width)
+{
+  config_.min_range = min_range;
+  config_.max_range = max_range;
 
-    //converting angle parameters into the velodyne reference (rad)
-    config_.tmp_min_angle = view_direction + view_width/2;
-    config_.tmp_max_angle = view_direction - view_width/2;
-    
-    //computing positive modulo to keep theses angles into [0;2*M_PI]
-    config_.tmp_min_angle = fmod(fmod(config_.tmp_min_angle,2*M_PI) + 2*M_PI,2*M_PI);
-    config_.tmp_max_angle = fmod(fmod(config_.tmp_max_angle,2*M_PI) + 2*M_PI,2*M_PI);
-    
-    //converting into the hardware velodyne ref (negative yaml and degrees)
-    //adding 0.5 perfomrs a centered double to int conversion 
-    config_.min_angle = 100 * (2*M_PI - config_.tmp_min_angle) * 180 / M_PI + 0.5;
-    config_.max_angle = 100 * (2*M_PI - config_.tmp_max_angle) * 180 / M_PI + 0.5;
-    if (config_.min_angle == config_.max_angle)
-    {
-      //avoid returning empty cloud if min_angle = max_angle
-      config_.min_angle = 0;
-      config_.max_angle = 36000;
-    }
+  // converting angle parameters into the velodyne reference (rad)
+  config_.tmp_min_angle = view_direction + view_width / 2;
+  config_.tmp_max_angle = view_direction - view_width / 2;
+
+  // computing positive modulo to keep theses angles into [0;2*M_PI]
+  config_.tmp_min_angle = fmod(fmod(config_.tmp_min_angle, 2 * M_PI) + 2 * M_PI, 2 * M_PI);
+  config_.tmp_max_angle = fmod(fmod(config_.tmp_max_angle, 2 * M_PI) + 2 * M_PI, 2 * M_PI);
+
+  // converting into the hardware velodyne ref (negative yaml and degrees)
+  // adding 0.5 perfomrs a centered double to int conversion
+  config_.min_angle = 100 * (2 * M_PI - config_.tmp_min_angle) * 180 / M_PI + 0.5;
+  config_.max_angle = 100 * (2 * M_PI - config_.tmp_max_angle) * 180 / M_PI + 0.5;
+  if (config_.min_angle == config_.max_angle) {
+    // avoid returning empty cloud if min_angle = max_angle
+    config_.min_angle = 0;
+    config_.max_angle = 36000;
+  }
+}
+
+/** Set up for on-line operation. */
+int RawData::setup(ros::NodeHandle private_nh)
+{
+  // get path to angles.config file for this device
+  if (!private_nh.getParam("calibration", config_.calibrationFile)) {
+    ROS_ERROR_STREAM("No calibration angles specified! Using test values!");
+
+    // have to use something: grab unit test version as a default
+    std::string pkgPath = ros::package::getPath("velodyne_pointcloud");
+    config_.calibrationFile = pkgPath + "/params/64e_utexas.yaml";
   }
 
-  /** Set up for on-line operation. */
-  int RawData::setup(ros::NodeHandle private_nh)
-  {
-    // get path to angles.config file for this device
-    if (!private_nh.getParam("calibration", config_.calibrationFile))
-      {
-        ROS_ERROR_STREAM("No calibration angles specified! Using test values!");
+  ROS_INFO_STREAM("correction angles: " << config_.calibrationFile);
 
-        // have to use something: grab unit test version as a default
-        std::string pkgPath = ros::package::getPath("velodyne_pointcloud");
-        config_.calibrationFile = pkgPath + "/params/64e_utexas.yaml";
+  calibration_.read(config_.calibrationFile);
+  if (!calibration_.initialized) {
+    ROS_ERROR_STREAM("Unable to open calibration file: " << config_.calibrationFile);
+    return -1;
+  }
+
+  ROS_INFO_STREAM("Number of lasers: " << calibration_.num_lasers << ".");
+
+  if (!private_nh.getParam("device_model", config_.deviceModel)) {
+    ROS_WARN_STREAM("device_model not specified");
+  }
+
+  if (calibration_.num_lasers == 16) {
+    vlp_spec_ = VLP_16_SPEC;
+    is_vlp_ = true;
+  } else if (config_.deviceModel == "VLP32") {
+    vlp_spec_ = VLP_32_SPEC;
+    is_vlp_ = true;
+    // Print corrections
+    std::vector<float> elev_spec = {
+      -25.0,  -1.0,   -1.667, -15.639, -11.31, 0.0,    -0.667, -8.843, -7.254, 0.333,  -0.333,
+      -6.148, -5.333, 1.333,  0.667,   -4.0,   -4.667, 1.667,  1.0,    -3.667, -3.333, 3.333,
+      2.333,  -2.667, -3.0,   7.0,     4.667,  -2.333, -2.0,   15.0,   10.333, -1.333
+    };
+    std::vector<float> az_spec = { 1.4,  -4.2, 1.4,  -1.4, 1.4,  -1.4, 4.2,  -1.4, 1.4,  -4.2, 1.4,
+                                   -1.4, 4.2,  -1.4, 4.2,  -1.4, 1.4,  -4.2, 1.4,  -4.2, 4.2,  -1.4,
+                                   1.4,  -1.4, 1.4,  -1.4, 1.4,  -4.2, 4.2,  -1.4, 1.4,  -1.4 };
+    for (int i = 0; i < 32; ++i) {
+      std::printf("Laser: %d Elevation angle: %.3f, spec: %.3f. Azimuth offset: %.3f, spec: %.3f\n",
+                  i, 180. / M_PI * std::asin(calibration_.laser_corrections[i].sin_vert_correction),
+                  elev_spec[i],
+                  180. / M_PI * std::asin(calibration_.laser_corrections[i].sin_rot_correction),
+                  az_spec[i]);
+    }
+    // The calibration file has negative angles for azimuth correction -> w/o that output is crap...
+  } else {
+    is_vlp_ = false;
+  }
+
+  // Set up cached values for sin and cos of all the possible headings
+  for (uint16_t rot_index = 0; rot_index < ROTATION_MAX_UNITS; ++rot_index) {
+    float rotation = angles::from_degrees(ROTATION_RESOLUTION * rot_index);
+    cos_rot_table_[rot_index] = cosf(rotation);
+    sin_rot_table_[rot_index] = sinf(rotation);
+  }
+  return 0;
+}
+
+/** @brief convert raw packet to point cloud
+ *
+ *  @param pkt raw packet to unpack
+ *  @param pc shared pointer to point cloud (points are appended)
+ */
+float RawData::unpack(const velodyne_msgs::VelodynePacket& pkt, VPointCloud& pc, size_t* valid_pnts) const
+{
+  ROS_DEBUG_STREAM("Received packet, time: " << pkt.stamp);
+
+  /** special parsing for the VLP16 and VLP32 **/
+  if (is_vlp_) {
+    return unpack_vlp(pkt, pc, valid_pnts);
+  }
+
+  const raw_packet_t* raw = (const raw_packet_t*)&pkt.data[0];
+
+  for (int i = 0; i < BLOCKS_PER_PACKET; i++) {
+    // upper bank lasers are numbered [0..31]
+    // NOTE: this is a change from the old velodyne_common implementation
+    int bank_origin = 0;
+    if (raw->blocks[i].header == LOWER_BANK) {
+      // lower bank lasers are [32..63]
+      bank_origin = 32;
+    }
+
+    for (int j = 0, k = 0; j < SCANS_PER_BLOCK; j++, k += RAW_SCAN_SIZE) {
+      float x, y, z;
+      float intensity;
+      uint8_t laser_number; ///< hardware laser number
+
+      laser_number = j + bank_origin;
+      const velodyne_pointcloud::LaserCorrection& corrections =
+          calibration_.laser_corrections.at(laser_number);
+
+      /** Position Calculation */
+
+      union two_bytes tmp;
+      tmp.bytes[0] = raw->blocks[i].data[k];
+      tmp.bytes[1] = raw->blocks[i].data[k + 1];
+      /*condition added to avoid calculating points which are not
+        in the interesting defined area (min_angle < area < max_angle)*/
+      if ((raw->blocks[i].rotation >= config_.min_angle &&
+           raw->blocks[i].rotation <= config_.max_angle && config_.min_angle < config_.max_angle) ||
+          (config_.min_angle > config_.max_angle &&
+           (raw->blocks[i].rotation <= config_.max_angle ||
+            raw->blocks[i].rotation >= config_.min_angle))) {
+        float distance = tmp.uint * DISTANCE_RESOLUTION;
+        distance += corrections.dist_correction;
+
+        float cos_vert_angle = corrections.cos_vert_correction;
+        float sin_vert_angle = corrections.sin_vert_correction;
+        float cos_rot_correction = corrections.cos_rot_correction;
+        float sin_rot_correction = corrections.sin_rot_correction;
+
+        // cos(a-b) = cos(a)*cos(b) + sin(a)*sin(b)
+        // sin(a-b) = sin(a)*cos(b) - cos(a)*sin(b)
+        float cos_rot_angle = cos_rot_table_[raw->blocks[i].rotation] * cos_rot_correction +
+                              sin_rot_table_[raw->blocks[i].rotation] * sin_rot_correction;
+        float sin_rot_angle = sin_rot_table_[raw->blocks[i].rotation] * cos_rot_correction -
+                              cos_rot_table_[raw->blocks[i].rotation] * sin_rot_correction;
+
+        float horiz_offset = corrections.horiz_offset_correction;
+        float vert_offset = corrections.vert_offset_correction;
+
+        // Compute the distance in the xy plane (w/o accounting for rotation)
+        /**the new term of 'vert_offset * sin_vert_angle'
+         * was added to the expression due to the mathemathical
+         * model we used.
+         */
+        float xy_distance = distance * cos_vert_angle - vert_offset * sin_vert_angle;
+
+        // Calculate temporal X, use absolute value.
+        float xx = xy_distance * sin_rot_angle - horiz_offset * cos_rot_angle;
+        // Calculate temporal Y, use absolute value
+        float yy = xy_distance * cos_rot_angle + horiz_offset * sin_rot_angle;
+        if (xx < 0)
+          xx = -xx;
+        if (yy < 0)
+          yy = -yy;
+
+        // Get 2points calibration values,Linear interpolation to get distance
+        // correction for X and Y, that means distance correction use
+        // different value at different distance
+        float distance_corr_x = 0;
+        float distance_corr_y = 0;
+        if (corrections.two_pt_correction_available) {
+          distance_corr_x = (corrections.dist_correction - corrections.dist_correction_x) *
+                                (xx - 2.4) / (25.04 - 2.4) +
+                            corrections.dist_correction_x;
+          distance_corr_x -= corrections.dist_correction;
+          distance_corr_y = (corrections.dist_correction - corrections.dist_correction_y) *
+                                (yy - 1.93) / (25.04 - 1.93) +
+                            corrections.dist_correction_y;
+          distance_corr_y -= corrections.dist_correction;
+        }
+
+        float distance_x = distance + distance_corr_x;
+        /**the new term of 'vert_offset * sin_vert_angle'
+         * was added to the expression due to the mathemathical
+         * model we used.
+         */
+        xy_distance = distance_x * cos_vert_angle - vert_offset * sin_vert_angle;
+        /// the expression wiht '-' is proved to be better than the one with '+'
+        x = xy_distance * sin_rot_angle - horiz_offset * cos_rot_angle;
+
+        float distance_y = distance + distance_corr_y;
+        xy_distance = distance_y * cos_vert_angle - vert_offset * sin_vert_angle;
+        /**the new term of 'vert_offset * sin_vert_angle'
+         * was added to the expression due to the mathemathical
+         * model we used.
+         */
+        y = xy_distance * cos_rot_angle + horiz_offset * sin_rot_angle;
+
+        // Using distance_y is not symmetric, but the velodyne manual
+        // does this.
+        /**the new term of 'vert_offset * cos_vert_angle'
+         * was added to the expression due to the mathemathical
+         * model we used.
+         */
+        z = distance_y * sin_vert_angle + vert_offset * cos_vert_angle;
+
+        /** Use standard ROS coordinate system (right-hand rule) */
+        float x_coord = y;
+        float y_coord = -x;
+        float z_coord = z;
+
+        /** Intensity Calculation */
+
+        float min_intensity = corrections.min_intensity;
+        float max_intensity = corrections.max_intensity;
+
+        intensity = raw->blocks[i].data[k + 2];
+
+        float focal_offset = 256 * (1 - corrections.focal_distance / 13100) *
+                             (1 - corrections.focal_distance / 13100);
+        float focal_slope = corrections.focal_slope;
+        intensity += focal_slope * (abs(focal_offset -
+                                        256 * (1 - static_cast<float>(tmp.uint) / 65535) *
+                                            (1 - static_cast<float>(tmp.uint) / 65535)));
+        intensity = (intensity < min_intensity) ? min_intensity : intensity;
+        intensity = (intensity > max_intensity) ? max_intensity : intensity;
+
+        if (pointInRange(distance)) {
+          // convert polar coordinates to Euclidean XYZ
+          VPoint point;
+          point.ring = corrections.laser_ring;
+          point.x = x_coord;
+          point.y = y_coord;
+          point.z = z_coord;
+          point.intensity = intensity;
+
+          // append this point to the cloud
+          pc.points.push_back(point);
+          ++pc.width;
+        }
       }
-
-    ROS_INFO_STREAM("correction angles: " << config_.calibrationFile);
-
-    calibration_.read(config_.calibrationFile);
-    if (!calibration_.initialized) {
-      ROS_ERROR_STREAM("Unable to open calibration file: " << 
-          config_.calibrationFile);
-      return -1;
     }
-    
-    ROS_INFO_STREAM("Number of lasers: " << calibration_.num_lasers << ".");
+  }
+  return -1.0;
+}
 
-    if (!private_nh.getParam("device_model", config_.deviceModel)) {
-      ROS_WARN_STREAM("device_model not specified");
+/** @brief convert raw VLP16 and VLP32 packet to point cloud
+ *
+ *  @param pkt raw packet to unpack
+ *  @param pc shared pointer to point cloud (points are appended)
+ */
+float RawData::unpack_vlp(const velodyne_msgs::VelodynePacket& pkt, VPointCloud& pc,
+                          size_t* valid_pnts) const
+{
+  float azimuth;
+  float azimuth_diff;
+  float last_azimuth_diff = 0;
+  float azimuth_corrected_f;
+  int azimuth_corrected;
+  float x, y, z;
+  float intensity;
+  float slice_angle = 0.0;
+
+  if (vlp_spec_.lasers_per_firing_seq == 32) {
+    ROS_INFO_THROTTLE(60, "Unpacking VLP32");
+    assert(vlp_spec_.firing_seqs_per_block == 1);
+  } else {
+    ROS_INFO_THROTTLE(60, "Unpacking VLP16");
+  }
+
+  const raw_packet_t* raw = (const raw_packet_t*)&pkt.data[0];
+
+  ROS_INFO_THROTTLE(60, "Return Mode: 0x%X, Product ID: 0x%X", pkt.data[1204], pkt.data[1205]);
+
+  std::set<std::tuple<float, float, float>> pnts_set; // expensive -- just bug-hunting!!!
+  size_t duplicates = 0;
+  size_t num_ok = 0;
+  size_t num_filtered_azimuth = 0;
+  size_t num_filtered_range = 0;
+
+  for (int block = 0; block < BLOCKS_PER_PACKET; block++) {
+    // Each block has 2b flag, 2b az, 32*(2b dist, 1b reflectivity)
+
+    // ignore packets with mangled or otherwise different contents
+    if (UPPER_BANK != raw->blocks[block].header) { // b 0,1
+      // Do not flood the log with messages, only issue at most one
+      // of these warnings per minute.
+      ROS_WARN_STREAM_THROTTLE(60, "skipping invalid VLP packet: block "
+                                       << block << " header value is "
+                                       << raw->blocks[block].header);
+      return -1; // bad packet: skip the rest
     }
 
-    if (calibration_.num_lasers == 16) {
-      vlp_spec_ = VLP_16_SPEC;
-      is_vlp_ = true;
-    } else if (config_.deviceModel == "VLP32") {
-      vlp_spec_ = VLP_32_SPEC;
-      is_vlp_ = true;
+    // Calculate difference between current and next block's azimuth angle.
+    azimuth = (float)(raw->blocks[block].rotation); // b 2,3
+
+    if (block < (BLOCKS_PER_PACKET - 1)) {
+      azimuth_diff =
+          (float)((36000 + raw->blocks[block + 1].rotation - raw->blocks[block].rotation) % 36000);
+      slice_angle += azimuth_diff;
+      last_azimuth_diff = azimuth_diff;
     } else {
-      is_vlp_ = false;
+      azimuth_diff = last_azimuth_diff;
     }
 
-    // Set up cached values for sin and cos of all the possible headings
-    for (uint16_t rot_index = 0; rot_index < ROTATION_MAX_UNITS; ++rot_index) {
-      float rotation = angles::from_degrees(ROTATION_RESOLUTION * rot_index);
-      cos_rot_table_[rot_index] = cosf(rotation);
-      sin_rot_table_[rot_index] = sinf(rotation);
-    }
-   return 0;
-  }
+    /* configuration for VLP32C:
 
-  /** @brief convert raw packet to point cloud
-   *
-   *  @param pkt raw packet to unpack
-   *  @param pc shared pointer to point cloud (points are appended)
-   */
-  float RawData::unpack(const velodyne_msgs::VelodynePacket &pkt,
-                       VPointCloud &pc)
-  {
-    ROS_DEBUG_STREAM("Received packet, time: " << pkt.stamp);
-    
-    /** special parsing for the VLP16 and VLP32 **/
-    if (is_vlp_)
-    {
-      return unpack_vlp(pkt, pc);
-    }
-    
-    const raw_packet_t *raw = (const raw_packet_t *) &pkt.data[0];
+       firing_seqs_per_block = 1
+       lasers_per_firing_seq = 32
+       lasers_per_firing     = 2
+       firing_duration;      = 2.304  [us]
+       firing_seq_duration   = 55.296 [us]
+       block_duration        = 55.296 [us] = firing_seq_duration * firing_seqs_per_block
+       distance_resolution   = 0.004  [m]
 
-    for (int i = 0; i < BLOCKS_PER_PACKET; i++) {
-
-      // upper bank lasers are numbered [0..31]
-      // NOTE: this is a change from the old velodyne_common implementation
-      int bank_origin = 0;
-      if (raw->blocks[i].header == LOWER_BANK) {
-        // lower bank lasers are [32..63]
-        bank_origin = 32;
-      }
-
-      for (int j = 0, k = 0; j < SCANS_PER_BLOCK; j++, k += RAW_SCAN_SIZE) {
-        
-        float x, y, z;
-        float intensity;
-        uint8_t laser_number;       ///< hardware laser number
-
-        laser_number = j + bank_origin;
-        velodyne_pointcloud::LaserCorrection &corrections = 
-          calibration_.laser_corrections[laser_number];
+       RAW_SCAN_SIZE = 3 (bytes)
+    */
+    // Go trough the 32, 3 byte laser hits
+    for (int firing_seq = 0, k = 0; firing_seq < vlp_spec_.firing_seqs_per_block; firing_seq++) {
+      for (int laser = 0; laser < vlp_spec_.lasers_per_firing_seq; laser++, k += RAW_SCAN_SIZE) {
+        const velodyne_pointcloud::LaserCorrection& corrections = calibration_.laser_corrections.at(laser);
 
         /** Position Calculation */
-
         union two_bytes tmp;
-        tmp.bytes[0] = raw->blocks[i].data[k];
-        tmp.bytes[1] = raw->blocks[i].data[k+1];
+        tmp.bytes[0] = raw->blocks[block].data[k];
+        tmp.bytes[1] = raw->blocks[block].data[k + 1];
+
+        /** correct for the laser rotation as a function of timing during the firings **/
+        float firing_offset = (laser / vlp_spec_.lasers_per_firing) * vlp_spec_.firing_duration;
+        float firing_seq_offset = firing_seq * vlp_spec_.firing_seq_duration;
+        azimuth_corrected_f = azimuth + (azimuth_diff * (firing_offset + firing_seq_offset) /
+                                         vlp_spec_.block_duration);
+        azimuth_corrected = ((int)round(azimuth_corrected_f)) % 36000;
+
         /*condition added to avoid calculating points which are not
           in the interesting defined area (min_angle < area < max_angle)*/
-        if ((raw->blocks[i].rotation >= config_.min_angle 
-             && raw->blocks[i].rotation <= config_.max_angle 
-             && config_.min_angle < config_.max_angle)
-             ||(config_.min_angle > config_.max_angle 
-             && (raw->blocks[i].rotation <= config_.max_angle 
-             || raw->blocks[i].rotation >= config_.min_angle))){
-          float distance = tmp.uint * DISTANCE_RESOLUTION;
+        if ((azimuth_corrected >= config_.min_angle && azimuth_corrected <= config_.max_angle &&
+             config_.min_angle < config_.max_angle) ||
+            (config_.min_angle > config_.max_angle &&
+             (azimuth_corrected <= config_.max_angle || azimuth_corrected >= config_.min_angle))) {
+          // convert polar coordinates to Euclidean XYZ
+          float distance = tmp.uint * vlp_spec_.distance_resolution;
           distance += corrections.dist_correction;
-  
+
           float cos_vert_angle = corrections.cos_vert_correction;
           float sin_vert_angle = corrections.sin_vert_correction;
           float cos_rot_correction = corrections.cos_rot_correction;
           float sin_rot_correction = corrections.sin_rot_correction;
-  
+
           // cos(a-b) = cos(a)*cos(b) + sin(a)*sin(b)
           // sin(a-b) = sin(a)*cos(b) - cos(a)*sin(b)
-          float cos_rot_angle = 
-            cos_rot_table_[raw->blocks[i].rotation] * cos_rot_correction + 
-            sin_rot_table_[raw->blocks[i].rotation] * sin_rot_correction;
-          float sin_rot_angle = 
-            sin_rot_table_[raw->blocks[i].rotation] * cos_rot_correction - 
-            cos_rot_table_[raw->blocks[i].rotation] * sin_rot_correction;
-  
+          float cos_rot_angle = cos_rot_table_[azimuth_corrected] * cos_rot_correction +
+                                sin_rot_table_[azimuth_corrected] * sin_rot_correction;
+          float sin_rot_angle = sin_rot_table_[azimuth_corrected] * cos_rot_correction -
+                                cos_rot_table_[azimuth_corrected] * sin_rot_correction;
+
           float horiz_offset = corrections.horiz_offset_correction;
           float vert_offset = corrections.vert_offset_correction;
-  
+
           // Compute the distance in the xy plane (w/o accounting for rotation)
           /**the new term of 'vert_offset * sin_vert_angle'
            * was added to the expression due to the mathemathical
            * model we used.
            */
           float xy_distance = distance * cos_vert_angle - vert_offset * sin_vert_angle;
-  
+
           // Calculate temporal X, use absolute value.
           float xx = xy_distance * sin_rot_angle - horiz_offset * cos_rot_angle;
           // Calculate temporal Y, use absolute value
           float yy = xy_distance * cos_rot_angle + horiz_offset * sin_rot_angle;
-          if (xx < 0) xx=-xx;
-          if (yy < 0) yy=-yy;
-    
+          if (xx < 0)
+            xx = -xx;
+          if (yy < 0)
+            yy = -yy;
+
           // Get 2points calibration values,Linear interpolation to get distance
           // correction for X and Y, that means distance correction use
           // different value at different distance
           float distance_corr_x = 0;
           float distance_corr_y = 0;
           if (corrections.two_pt_correction_available) {
-            distance_corr_x = 
-              (corrections.dist_correction - corrections.dist_correction_x)
-                * (xx - 2.4) / (25.04 - 2.4) 
-              + corrections.dist_correction_x;
+            distance_corr_x = (corrections.dist_correction - corrections.dist_correction_x) *
+                                  (xx - 2.4) / (25.04 - 2.4) +
+                              corrections.dist_correction_x;
             distance_corr_x -= corrections.dist_correction;
-            distance_corr_y = 
-              (corrections.dist_correction - corrections.dist_correction_y)
-                * (yy - 1.93) / (25.04 - 1.93)
-              + corrections.dist_correction_y;
+            distance_corr_y = (corrections.dist_correction - corrections.dist_correction_y) *
+                                  (yy - 1.93) / (25.04 - 1.93) +
+                              corrections.dist_correction_y;
             distance_corr_y -= corrections.dist_correction;
           }
-  
+
           float distance_x = distance + distance_corr_x;
           /**the new term of 'vert_offset * sin_vert_angle'
            * was added to the expression due to the mathemathical
            * model we used.
            */
-          xy_distance = distance_x * cos_vert_angle - vert_offset * sin_vert_angle ;
-          ///the expression wiht '-' is proved to be better than the one with '+'
+          xy_distance = distance_x * cos_vert_angle - vert_offset * sin_vert_angle;
           x = xy_distance * sin_rot_angle - horiz_offset * cos_rot_angle;
-  
+
           float distance_y = distance + distance_corr_y;
-          xy_distance = distance_y * cos_vert_angle - vert_offset * sin_vert_angle ;
           /**the new term of 'vert_offset * sin_vert_angle'
            * was added to the expression due to the mathemathical
            * model we used.
            */
+          xy_distance = distance_y * cos_vert_angle - vert_offset * sin_vert_angle;
           y = xy_distance * cos_rot_angle + horiz_offset * sin_rot_angle;
-  
+
           // Using distance_y is not symmetric, but the velodyne manual
           // does this.
           /**the new term of 'vert_offset * cos_vert_angle'
            * was added to the expression due to the mathemathical
            * model we used.
            */
-          z = distance_y * sin_vert_angle + vert_offset*cos_vert_angle;
-  
+          z = distance_y * sin_vert_angle + vert_offset * cos_vert_angle;
+
+
           /** Use standard ROS coordinate system (right-hand rule) */
           float x_coord = y;
           float y_coord = -x;
           float z_coord = z;
-  
+
           /** Intensity Calculation */
-  
           float min_intensity = corrections.min_intensity;
           float max_intensity = corrections.max_intensity;
-  
-          intensity = raw->blocks[i].data[k+2];
-  
-          float focal_offset = 256 
-                             * (1 - corrections.focal_distance / 13100) 
-                             * (1 - corrections.focal_distance / 13100);
+
+          intensity = raw->blocks[block].data[k + 2];
+
+          float focal_offset = 256 * (1 - corrections.focal_distance / 13100) *
+                               (1 - corrections.focal_distance / 13100);
           float focal_slope = corrections.focal_slope;
-          intensity += focal_slope * (abs(focal_offset - 256 * 
-            (1 - static_cast<float>(tmp.uint)/65535)*(1 - static_cast<float>(tmp.uint)/65535)));
+          intensity += focal_slope *
+                       (abs(focal_offset - 256 * (1 - tmp.uint / 65535) * (1 - tmp.uint / 65535)));
           intensity = (intensity < min_intensity) ? min_intensity : intensity;
           intensity = (intensity > max_intensity) ? max_intensity : intensity;
-  
+
           if (pointInRange(distance)) {
-  
-            // convert polar coordinates to Euclidean XYZ
+            // append this point to the cloud
             VPoint point;
             point.ring = corrections.laser_ring;
             point.x = x_coord;
             point.y = y_coord;
             point.z = z_coord;
             point.intensity = intensity;
-  
-            // append this point to the cloud
+
+            auto pnt_tuple = std::make_tuple(point.x, point.y, point.z);
+            if (pnts_set.count(pnt_tuple) == 0) {
+              pnts_set.insert(pnt_tuple);
+            } else {
+              duplicates++;
+            }
+
+            num_ok++;
             pc.points.push_back(point);
             ++pc.width;
+          } else {
+            num_filtered_range++;
           }
+        } else {
+          num_filtered_azimuth++;
         }
-      }
-    }
-    return -1.0;
+      } // end for laser
+    }   // end for firing_seq
+  }     // end for block
+
+  if (valid_pnts != nullptr) {
+    *valid_pnts = num_ok;
   }
-  
-  /** @brief convert raw VLP16 and VLP32 packet to point cloud
-   *
-   *  @param pkt raw packet to unpack
-   *  @param pc shared pointer to point cloud (points are appended)
-   */
-  float RawData::unpack_vlp(const velodyne_msgs::VelodynePacket &pkt,
-                             VPointCloud &pc)
-  {
-    float azimuth;
-    float azimuth_diff;
-    float last_azimuth_diff=0;
-    float azimuth_corrected_f;
-    int azimuth_corrected;
-    float x, y, z;
-    float intensity;
-    float slice_angle = 0.0;
-
-    const raw_packet_t *raw = (const raw_packet_t *) &pkt.data[0];
-
-    for (int block = 0; block < BLOCKS_PER_PACKET; block++) {
-
-      // ignore packets with mangled or otherwise different contents
-      if (UPPER_BANK != raw->blocks[block].header) {
-        // Do not flood the log with messages, only issue at most one
-        // of these warnings per minute.
-        ROS_WARN_STREAM_THROTTLE(60, "skipping invalid VLP packet: block "
-                                 << block << " header value is "
-                                 << raw->blocks[block].header);
-        return -1;                         // bad packet: skip the rest
-      }
-
-      // Calculate difference between current and next block's azimuth angle.
-      azimuth = (float)(raw->blocks[block].rotation);
-
-      //Debug 
-      //std::cout << "Block: " << block << ", Azimuth: " << azimuth << std::endl;
-
-      if (block < (BLOCKS_PER_PACKET-1)){
-        azimuth_diff = (float)((36000 + raw->blocks[block+1].rotation - raw->blocks[block].rotation)%36000);
-        slice_angle += azimuth_diff;
-        last_azimuth_diff = azimuth_diff;
-      }else{
-        azimuth_diff = last_azimuth_diff;
-      }
-
-      for (int firing_seq=0, k=0; firing_seq < vlp_spec_.firing_seqs_per_block; firing_seq++){
-        for (int laser=0; laser < vlp_spec_.lasers_per_firing_seq; laser++, k+=RAW_SCAN_SIZE){
-          velodyne_pointcloud::LaserCorrection &corrections = 
-            calibration_.laser_corrections[laser];
-
-          /** Position Calculation */
-          union two_bytes tmp;
-          tmp.bytes[0] = raw->blocks[block].data[k];
-          tmp.bytes[1] = raw->blocks[block].data[k+1];
-          
-          /** correct for the laser rotation as a function of timing during the firings **/
-          float firing_offset = (laser / vlp_spec_.lasers_per_firing) * vlp_spec_.firing_duration;
-          float firing_seq_offset = firing_seq * vlp_spec_.firing_seq_duration;
-          azimuth_corrected_f = azimuth + (azimuth_diff * (firing_offset + firing_seq_offset) / vlp_spec_.block_duration);
-          azimuth_corrected = ((int)round(azimuth_corrected_f)) % 36000;
-          
-          /*condition added to avoid calculating points which are not
-            in the interesting defined area (min_angle < area < max_angle)*/
-          if ((azimuth_corrected >= config_.min_angle 
-               && azimuth_corrected <= config_.max_angle 
-               && config_.min_angle < config_.max_angle)
-               ||(config_.min_angle > config_.max_angle 
-               && (azimuth_corrected <= config_.max_angle 
-               || azimuth_corrected >= config_.min_angle))){
-
-            // convert polar coordinates to Euclidean XYZ
-            float distance = tmp.uint * vlp_spec_.distance_resolution;
-            distance += corrections.dist_correction;
-            
-            float cos_vert_angle = corrections.cos_vert_correction;
-            float sin_vert_angle = corrections.sin_vert_correction;
-            float cos_rot_correction = corrections.cos_rot_correction;
-            float sin_rot_correction = corrections.sin_rot_correction;
-    
-            // cos(a-b) = cos(a)*cos(b) + sin(a)*sin(b)
-            // sin(a-b) = sin(a)*cos(b) - cos(a)*sin(b)
-            float cos_rot_angle = 
-              cos_rot_table_[azimuth_corrected] * cos_rot_correction + 
-              sin_rot_table_[azimuth_corrected] * sin_rot_correction;
-            float sin_rot_angle = 
-              sin_rot_table_[azimuth_corrected] * cos_rot_correction - 
-              cos_rot_table_[azimuth_corrected] * sin_rot_correction;
-    
-            float horiz_offset = corrections.horiz_offset_correction;
-            float vert_offset = corrections.vert_offset_correction;
-    
-            // Compute the distance in the xy plane (w/o accounting for rotation)
-            /**the new term of 'vert_offset * sin_vert_angle'
-             * was added to the expression due to the mathemathical
-             * model we used.
-             */
-            float xy_distance = distance * cos_vert_angle - vert_offset * sin_vert_angle;
-    
-            // Calculate temporal X, use absolute value.
-            float xx = xy_distance * sin_rot_angle - horiz_offset * cos_rot_angle;
-            // Calculate temporal Y, use absolute value
-            float yy = xy_distance * cos_rot_angle + horiz_offset * sin_rot_angle;
-            if (xx < 0) xx=-xx;
-            if (yy < 0) yy=-yy;
-      
-            // Get 2points calibration values,Linear interpolation to get distance
-            // correction for X and Y, that means distance correction use
-            // different value at different distance
-            float distance_corr_x = 0;
-            float distance_corr_y = 0;
-            if (corrections.two_pt_correction_available) {
-              distance_corr_x = 
-                (corrections.dist_correction - corrections.dist_correction_x)
-                  * (xx - 2.4) / (25.04 - 2.4) 
-                + corrections.dist_correction_x;
-              distance_corr_x -= corrections.dist_correction;
-              distance_corr_y = 
-                (corrections.dist_correction - corrections.dist_correction_y)
-                  * (yy - 1.93) / (25.04 - 1.93)
-                + corrections.dist_correction_y;
-              distance_corr_y -= corrections.dist_correction;
-            }
-    
-            float distance_x = distance + distance_corr_x;
-            /**the new term of 'vert_offset * sin_vert_angle'
-             * was added to the expression due to the mathemathical
-             * model we used.
-             */
-            xy_distance = distance_x * cos_vert_angle - vert_offset * sin_vert_angle ;
-            x = xy_distance * sin_rot_angle - horiz_offset * cos_rot_angle;
-    
-            float distance_y = distance + distance_corr_y;
-            /**the new term of 'vert_offset * sin_vert_angle'
-             * was added to the expression due to the mathemathical
-             * model we used.
-             */
-            xy_distance = distance_y * cos_vert_angle - vert_offset * sin_vert_angle ;
-            y = xy_distance * cos_rot_angle + horiz_offset * sin_rot_angle;
-    
-            // Using distance_y is not symmetric, but the velodyne manual
-            // does this.
-            /**the new term of 'vert_offset * cos_vert_angle'
-             * was added to the expression due to the mathemathical
-             * model we used.
-             */
-            z = distance_y * sin_vert_angle + vert_offset*cos_vert_angle;
-  
-    
-            /** Use standard ROS coordinate system (right-hand rule) */
-            float x_coord = y;
-            float y_coord = -x;
-            float z_coord = z;
-    
-            /** Intensity Calculation */
-            float min_intensity = corrections.min_intensity;
-            float max_intensity = corrections.max_intensity;
-    
-            intensity = raw->blocks[block].data[k+2];
-    
-            float focal_offset = 256 
-                               * (1 - corrections.focal_distance / 13100) 
-                               * (1 - corrections.focal_distance / 13100);
-            float focal_slope = corrections.focal_slope;
-            intensity += focal_slope * (abs(focal_offset - 256 * 
-              (1 - tmp.uint/65535)*(1 - tmp.uint/65535)));
-            intensity = (intensity < min_intensity) ? min_intensity : intensity;
-            intensity = (intensity > max_intensity) ? max_intensity : intensity;
-    
-            if (pointInRange(distance)) {
-    
-              // append this point to the cloud
-              VPoint point;
-              point.ring = corrections.laser_ring;
-              point.x = x_coord;
-              point.y = y_coord;
-              point.z = z_coord;
-              point.intensity = intensity;
-
-              pc.points.push_back(point);
-              ++pc.width;
-            }
-          }
-        }
-      }
-    }
-    return slice_angle;
-  }  
+  //  std::printf("%lu OK pnts in PKT, filtered: AZ: %lu RNG: %lu, duplicates: %lu, total=%lu, "
+  //              "slice now has %lu pnts\n",
+  //              num_ok, num_filtered_azimuth, num_filtered_range, duplicates,
+  //              num_ok + num_filtered_azimuth + num_filtered_range, pc.points.size());
+  return slice_angle;
+}
 
 } // namespace velodyne_rawdata


### PR DESCRIPTION
Found out that we were duplicating points in the output from the velodyne driver.

Pseudo-code for the problematic function (before fix): `void Convert::processScan(const velodyne_msgs::VelodyneScan::ConstPtr& scanMsg)`

```
callback(packets) {
    msg = []
    for(packet : packets) {
        if(sweep_done) {
            publish(combined)
            combined.clear()
        }
        msg.add(pkt)
        combined.add(msg)
    }
}
```

Note that `combined.add(msg)` adds a list that is growing with each iteration of the `for(packet: packtets)` loop! Luckily we had set len(packets) = 3 in a config file, so the resulting output "only" contained twice the number of points (~50% duplicates):

it 0: combined = []+[0] = [0]
it 1: combined = [0]+[0,1] = [0,0,1]
it 2: combined = [0,0,1] + [0,1,2] = [0,0,1,0,1,2]

I also did some cleanup.