### PR TITLE
Erik/lidar fast report

### DIFF
--- a/velodyne_pointcloud/CMakeLists.txt
+++ b/velodyne_pointcloud/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(velodyne_pointcloud)
 
+add_definitions("-std=c++11")
+
 set(${PROJECT_NAME}_CATKIN_DEPS
     angles
     nodelet
@@ -9,6 +11,9 @@ set(${PROJECT_NAME}_CATKIN_DEPS
     roslib
     sensor_msgs
     tf
+    tf2
+    tf2_ros
+    tf2_geometry_msgs
     velodyne_driver
     velodyne_msgs
     dynamic_reconfigure

--- a/velodyne_pointcloud/package.xml
+++ b/velodyne_pointcloud/package.xml
@@ -28,12 +28,12 @@
   <build_depend>velodyne_driver</build_depend>
   <build_depend>velodyne_msgs</build_depend>
   <build_depend>yaml-cpp</build_depend>
-  <build_depend>dynamic_reconfigure</build_depend>
-
-  <!-- these build dependencies are only needed for unit testing -->
+  <build_depend>dynamic_reconfigure</build_depend> 
   <build_depend>roslaunch</build_depend>
   <build_depend>rostest</build_depend>
+  <build_depend>tf2</build_depend>
   <build_depend>tf2_ros</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
 
   <run_depend>angles</run_depend>
   <run_depend>nodelet</run_depend>
@@ -48,6 +48,9 @@
   <run_depend>velodyne_msgs</run_depend>
   <run_depend>yaml-cpp</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
+  <run_depend>tf2</run_depend>
+  <run_depend>tf2_ros</run_depend>
+  <run_depend>tf2_geometry_msgs</run_depend>
 
   <export>
     <nodelet plugin="${prefix}/nodelets.xml"/>

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -106,7 +106,8 @@ void Convert::setupVisibilityAngles(ros::NodeHandle& node, ros::NodeHandle& priv
 
   // Look up yaw of velodyne relative to vehicle frame
   std::string frame_id;
-  if (!private_nh.param<std::string>("frame_id", frame_id, "")) {
+  if (!private_nh.getParam("frame_id", frame_id)) {
+    ROS_ERROR("Param frame_id not set!");
     throw std::logic_error("Param frame_id not set");
   }
 

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -88,8 +88,12 @@ void Convert::setupVisibilityAngles(ros::NodeHandle& node, ros::NodeHandle& priv
 
   // Relative to x-axis of vehicle frame, counter clock-wise
   // The "front" angle is the start angle for the left sensor, if it spins counter-cw
+
+  // -62.08 deg = -1.08350 rad Is a bit much
+  // -45 deg = 0.7853982 rad might be better
   float visibility_angle_left_front =
-      node.param("/config/vehicle/vehicle/visiblity_angle_left_front", -1.08350f);
+      node.param("/config/vehicle/vehicle/visiblity_angle_left_front", -0.7853982f);
+  // 360-114.25-62.08 = 183.67 deg = 3.20565f rad
   float visibility_angle_left_rear =
       node.param("/config/vehicle/vehicle/visiblity_angle_left_rear", 3.20565f);
 
@@ -97,7 +101,7 @@ void Convert::setupVisibilityAngles(ros::NodeHandle& node, ros::NodeHandle& priv
   float visibility_angle_right_rear =
       node.param("/config/vehicle/vehicle/visiblity_angle_right_rear", -3.20565f);
   float visibility_angle_right_front =
-      node.param("/config/vehicle/vehicle/visiblity_angle_right_front", 1.08350f);
+      node.param("/config/vehicle/vehicle/visiblity_angle_right_front", 0.7853982f);
 
 
   // Look up yaw of velodyne relative to vehicle frame

--- a/velodyne_pointcloud/src/conversions/convert.cc
+++ b/velodyne_pointcloud/src/conversions/convert.cc
@@ -15,20 +15,48 @@
 
 #include "convert.h"
 
+#include <geometry_msgs/TransformStamped.h>
 #include <pcl_conversions/pcl_conversions.h>
+#include <tf2/LinearMath/Matrix3x3.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+
+namespace {
+
+double getYawFromMsg(const geometry_msgs::TransformStamped& transform_msg)
+{
+  tf2::Quaternion quat_tf;
+  tf2::convert(transform_msg.transform.rotation, quat_tf);
+  tf2::Matrix3x3 m_tf(quat_tf);
+  double roll, pitch, yaw;
+  m_tf.getRPY(roll, pitch, yaw);
+  return yaw;
+}
+
+} // namespace
 
 namespace velodyne_pointcloud {
 /** @brief Constructor. */
 Convert::Convert(ros::NodeHandle node, ros::NodeHandle private_nh)
-  : data_(new velodyne_rawdata::RawData()), prev_azimuth_(0.0), prev_stamp_(ros::Time())
+  : data_(new velodyne_rawdata::RawData()), prev_azimuth_(-1.0), prev_stamp_(ros::Time())
 {
+  // Read configuration for our sensor
   data_->setup(private_nh);
+
+  setupVisibilityAngles(node, private_nh);
 
   accumulated_cloud_.width = 0;
   accumulated_cloud_.height = 1;
 
+  cropped_accumulated_cloud_.width = 0;
+  cropped_accumulated_cloud_.height = 1;
+
   // advertise output point cloud (before subscribing to input data)
   pointcloud_publisher_ = node.advertise<sensor_msgs::PointCloud2>("velodyne_points", 10);
+  cropped_pointcloud_publisher_ =
+      node.advertise<sensor_msgs::PointCloud2>("cropped_velodyne_points", 10);
 
   // advertise output deskew info
   deskew_info_publisher_ =
@@ -40,12 +68,94 @@ Convert::Convert(ros::NodeHandle node, ros::NodeHandle private_nh)
   f = boost::bind(&Convert::callback, this, _1, _2);
   srv_->setCallback(f);
 
+  synced_with_visibility_ = false;
+
+  last_sample_added_ = false;
+  start_full_sweep_ = start_cropped_sweep_ = std::chrono::steady_clock::now();
+
   // Add an extra entry for angle 0, for initial sweep
   deskew_info_.sweep_info.push_back(create_sweep_entry(prev_stamp_, 0.0));
 
   // subscribe to VelodyneScan packets
   velodyne_scan_ = node.subscribe("velodyne_packets", 10, &Convert::processScan, (Convert*)this,
                                   ros::TransportHints().tcpNoDelay(true));
+}
+
+void Convert::setupVisibilityAngles(ros::NodeHandle& node, ros::NodeHandle& private_nh)
+{
+  tf2_ros::Buffer tf_buffer;
+  tf2_ros::TransformListener tf_listener(tf_buffer);
+
+  // Relative to x-axis of vehicle frame, counter clock-wise
+  // The "front" angle is the start angle for the left sensor, if it spins counter-cw
+  float visibility_angle_left_front =
+      node.param("/config/vehicle/vehicle/visiblity_angle_left_front", -1.08350f);
+  float visibility_angle_left_rear =
+      node.param("/config/vehicle/vehicle/visiblity_angle_left_rear", 3.20565f);
+
+  // The "rear" angle is the start angle for the right sensor, if it spins counter-cw
+  float visibility_angle_right_rear =
+      node.param("/config/vehicle/vehicle/visiblity_angle_right_rear", -3.20565f);
+  float visibility_angle_right_front =
+      node.param("/config/vehicle/vehicle/visiblity_angle_right_front", 1.08350f);
+
+
+  // Look up yaw of velodyne relative to vehicle frame
+  std::string frame_id;
+  if (!private_nh.param<std::string>("frame_id", frame_id, "")) {
+    throw std::logic_error("Param frame_id not set");
+  }
+
+  ROS_INFO("Waiting for transfrom from sensor: %s to vehicle_frame", frame_id.c_str());
+
+  std::string errstr;
+  if (!tf_buffer.canTransform(frame_id, "vehicle_frame", ros::Time(0), ros::Duration(10),
+                              &errstr)) {
+    ROS_ERROR("Required transform %s -> vehicle_frame not found in 10 seconds",
+              ros::this_node::getName().c_str());
+    throw std::logic_error("Transform invalid");
+  }
+  geometry_msgs::TransformStamped veh_to_sensor =
+      tf_buffer.lookupTransform(frame_id, "vehicle_frame", ros::Time(0));
+  ROS_INFO("Transform to vehicle frame found");
+
+  double yaw_sens_veh = -getYawFromMsg(veh_to_sensor);
+  // are we the left or right sensor?
+  if (-veh_to_sensor.transform.translation.y >= 0) {
+    ROS_INFO("Using left sensor angles");
+    // left
+    visibility_angle_start_ = visibility_angle_left_front - yaw_sens_veh;
+    visibility_angle_end_ = visibility_angle_left_rear - yaw_sens_veh;
+  } else {
+    ROS_INFO("Using right sensor angles");
+    // right
+    visibility_angle_start_ = visibility_angle_right_rear - yaw_sens_veh;
+    visibility_angle_end_ = visibility_angle_right_front - yaw_sens_veh;
+  }
+
+  visibility_angle_start_ = 180.0 / M_PI * visibility_angle_start_;
+  visibility_angle_end_ = 180.0 / M_PI * visibility_angle_end_;
+
+  ROS_INFO("Counter clockwise angles sens frame: %.2f -> %.2f (yaw_sens: %.2f)",
+           visibility_angle_start_, visibility_angle_end_, 180.0 / M_PI * yaw_sens_veh);
+
+  // Convert angles to azimuth (degrees clockwise from X-axis)
+  // TODO, this is really weird (at page 38 in VLP32C manual, 0deg is towards the y-axis, but this
+  // works...)
+  visibility_angle_start_ = -visibility_angle_start_;
+  visibility_angle_end_ = -visibility_angle_end_;
+  while (visibility_angle_start_ < 0) {
+    visibility_angle_start_ += 360;
+  }
+  while (visibility_angle_end_ < 0) {
+    visibility_angle_end_ += 360;
+  }
+
+  // Because the sensor spins with INCREASING azimuth, we need to swap start and end angles
+  std::swap(visibility_angle_start_, visibility_angle_end_);
+
+  ROS_INFO("Will process points between azimuth %.2f -> %.2f deg.", visibility_angle_start_,
+           visibility_angle_end_);
 }
 
 void Convert::callback(velodyne_pointcloud::CloudNodeConfig& config, uint32_t level)
@@ -63,6 +173,51 @@ velodyne_msgs::VelodyneSweepInfo Convert::create_sweep_entry(ros::Time stamp, fl
   return sweep_info;
 }
 
+void Convert::emitFullSweep(const velodyne_msgs::VelodyneScan::ConstPtr& scanMsg)
+{
+  const auto t_end = std::chrono::steady_clock::now();
+  ROS_INFO("Full sweep acquisition in = %.2f ms",
+           std::chrono::duration_cast<std::chrono::nanoseconds>(t_end - start_full_sweep_).count() /
+               1.0e6);
+
+  accumulated_cloud_.header.stamp = pcl_conversions::toPCL(scanMsg->header).stamp;
+  accumulated_cloud_.header.frame_id = scanMsg->header.frame_id;
+  assert(accumulated_cloud_.width == accumulated_cloud_.points.size());
+
+  pointcloud_publisher_.publish(accumulated_cloud_);
+
+  deskew_info_.header.stamp = scanMsg->header.stamp;
+  deskew_info_.header.frame_id = scanMsg->header.frame_id;
+  deskew_info_publisher_.publish(deskew_info_);
+
+  // Clear data we are accumulating
+  accumulated_cloud_.points.clear();
+  accumulated_cloud_.width = 0;
+  deskew_info_.sweep_info.clear();
+
+  // Add an extra entry for angle 0, for next sweep
+  deskew_info_.sweep_info.push_back(create_sweep_entry(prev_stamp_, 0.0));
+}
+
+void Convert::emitCroppedSweep(const velodyne_msgs::VelodyneScan::ConstPtr& scanMsg)
+{
+  const auto t_end = std::chrono::steady_clock::now();
+  ROS_INFO(
+      "Cropped sweep acquisition in = %.2f ms",
+      std::chrono::duration_cast<std::chrono::nanoseconds>(t_end - start_cropped_sweep_).count() /
+          1.0e6);
+
+  cropped_accumulated_cloud_.header.stamp = pcl_conversions::toPCL(scanMsg->header).stamp;
+  cropped_accumulated_cloud_.header.frame_id = scanMsg->header.frame_id;
+  assert(cropped_accumulated_cloud_.width == cropped_accumulated_cloud_.points.size());
+
+  cropped_pointcloud_publisher_.publish(cropped_accumulated_cloud_);
+  // ROS_DEBUG("Publish cropped pc with %lu points", cropped_accumulated_cloud_.points.size());
+
+  cropped_accumulated_cloud_.points.clear();
+  cropped_accumulated_cloud_.width = 0;
+}
+
 /** @brief Callback for raw scan messages. */
 void Convert::processScan(const velodyne_msgs::VelodyneScan::ConstPtr& scanMsg)
 {
@@ -71,33 +226,74 @@ void Convert::processScan(const velodyne_msgs::VelodyneScan::ConstPtr& scanMsg)
         (const velodyne_rawdata::raw_packet_t*)&scanMsg->packets[i].data[0];
 
     // azimuth corresponds to the starting sweep angle for the current packet
+    // (0 deg is y-axis of velodyne, increasing CLOCK-WISE)
     float azimuth = float(raw->blocks[0].rotation) / 100.0;
+    // ROS_DEBUG("azimuth = %.2f", azimuth);
 
-    // azimuth value will wrap around after a full 360 degree sweep
-    if (azimuth < prev_azimuth_) {
-      // Publish data for the full sweep
-      accumulated_cloud_.header.stamp = pcl_conversions::toPCL(scanMsg->header).stamp;
-      accumulated_cloud_.header.frame_id = scanMsg->header.frame_id;
-      assert(accumulated_cloud_.width == accumulated_cloud_.points.size());
+    // wait until prev_azimuth -> azimuth containts start visibility angle
+    if (synced_with_visibility_) {
+      // azimuth value will wrap around after a full 360 degree sweep
+      if (azimuth < prev_azimuth_) {
+        emitFullSweep(scanMsg);
+        start_full_sweep_ = std::chrono::steady_clock::now();
+      }
 
-      pointcloud_publisher_.publish(accumulated_cloud_);
+      // Seen all the relevant parts of the sweep
+      if (prev_azimuth_ <= visibility_angle_end_ && visibility_angle_end_ <= azimuth) {
+        emitCroppedSweep(scanMsg);
+      }
 
-      deskew_info_.header.stamp = scanMsg->header.stamp;
-      deskew_info_.header.frame_id = scanMsg->header.frame_id;
-      deskew_info_publisher_.publish(deskew_info_);
+      size_t start_index = accumulated_cloud_.points.size();
 
-      // Clear data we are accumulating
-      accumulated_cloud_.points.clear();
-      accumulated_cloud_.width = 0;
-      deskew_info_.sweep_info.clear();
+      data_->unpackAndAdd(scanMsg->packets[i], accumulated_cloud_);
+      deskew_info_.sweep_info.push_back(create_sweep_entry(scanMsg->packets[i].stamp, azimuth));
 
-      // Add an extra entry for angle 0, for next sweep
-      deskew_info_.sweep_info.push_back(create_sweep_entry(prev_stamp_, 0.0));
+      if (visibility_angle_start_ > visibility_angle_end_) {
+        // Sweep we want to capture goes across 360 deg.
+        if (visibility_angle_start_ <= azimuth || azimuth <= visibility_angle_end_) {
+          for (size_t j = start_index; j < accumulated_cloud_.points.size(); ++j) {
+            cropped_accumulated_cloud_.points.push_back(accumulated_cloud_.points[j]);
+            ++cropped_accumulated_cloud_.width;
+          }
+          if (!last_sample_added_) {
+            start_cropped_sweep_ = std::chrono::steady_clock::now();
+          }
+          last_sample_added_ = true;
+        } else {
+          last_sample_added_ = false;
+        }
+      } else {
+        // Sweep doesn't cross 360 deg.
+        if (visibility_angle_start_ <= azimuth && azimuth <= visibility_angle_end_) {
+          for (size_t j = start_index; j < accumulated_cloud_.points.size(); ++j) {
+            cropped_accumulated_cloud_.points.push_back(accumulated_cloud_.points[j]);
+            ++cropped_accumulated_cloud_.width;
+          }
+          if (!last_sample_added_) {
+            start_cropped_sweep_ = std::chrono::steady_clock::now();
+          }
+          last_sample_added_ = true;
+        } else {
+          last_sample_added_ = false;
+        }
+      }
+    } else {
+      // Check that interval prev-curr overlaps start
+      if (azimuth < prev_azimuth_) { // interval overlaps 360
+        if (prev_azimuth_ >= 0 && prev_azimuth_ - 360 <= visibility_angle_start_ &&
+            visibility_angle_start_ <= azimuth) {
+          synced_with_visibility_ = true;
+          ROS_DEBUG("Azimuth synced");
+        }
+      } else {
+        if (prev_azimuth_ >= 0 && prev_azimuth_ <= visibility_angle_start_ &&
+            visibility_angle_start_ <= azimuth) {
+          synced_with_visibility_ = true;
+          ROS_DEBUG("Azimuth synced");
+        }
+      }
     }
 
-    data_->unpackAndAdd(scanMsg->packets[i], accumulated_cloud_);
-
-    deskew_info_.sweep_info.push_back(create_sweep_entry(scanMsg->packets[i].stamp, azimuth));
     prev_azimuth_ = azimuth;
     prev_stamp_ = scanMsg->packets[i].stamp;
   }

--- a/velodyne_pointcloud/src/conversions/convert.h
+++ b/velodyne_pointcloud/src/conversions/convert.h
@@ -17,24 +17,18 @@
 #ifndef _VELODYNE_POINTCLOUD_CONVERT_H_
 #define _VELODYNE_POINTCLOUD_CONVERT_H_ 1
 
-#include <ros/ros.h>
-
-#include <sensor_msgs/PointCloud2.h>
-#include <velodyne_pointcloud/rawdata.h>
-
 #include <dynamic_reconfigure/server.h>
-#include <velodyne_pointcloud/CloudNodeConfig.h>
-
+#include <ros/ros.h>
+#include <sensor_msgs/PointCloud2.h>
 #include <velodyne_msgs/VelodyneDeskewInfo.h>
 #include <velodyne_msgs/VelodyneSweepInfo.h>
-#include <chrono>
+#include <velodyne_pointcloud/CloudNodeConfig.h>
+#include <velodyne_pointcloud/rawdata.h>
 
 namespace velodyne_pointcloud {
 class Convert
 {
  public:
-  using TimePoint = std::chrono::time_point<std::chrono::steady_clock>;
-
   Convert(ros::NodeHandle node, ros::NodeHandle private_nh);
   ~Convert() = default;
 
@@ -72,10 +66,6 @@ class Convert
 
   float visibility_angle_start_;
   float visibility_angle_end_;
-
-  TimePoint start_full_sweep_;
-  TimePoint start_cropped_sweep_;
-  bool last_sample_added_;
 };
 } // namespace velodyne_pointcloud
 

--- a/velodyne_pointcloud/src/conversions/convert.h
+++ b/velodyne_pointcloud/src/conversions/convert.h
@@ -27,17 +27,21 @@
 
 #include <velodyne_msgs/VelodyneDeskewInfo.h>
 #include <velodyne_msgs/VelodyneSweepInfo.h>
+#include <chrono>
 
 namespace velodyne_pointcloud {
 class Convert
 {
  public:
+  using TimePoint = std::chrono::time_point<std::chrono::steady_clock>;
+
   Convert(ros::NodeHandle node, ros::NodeHandle private_nh);
-  ~Convert()
-  {
-  }
+  ~Convert() = default;
 
  private:
+  void emitFullSweep(const velodyne_msgs::VelodyneScan::ConstPtr& scanMsg);
+  void emitCroppedSweep(const velodyne_msgs::VelodyneScan::ConstPtr& scanMsg);
+  void setupVisibilityAngles(ros::NodeHandle& node, ros::NodeHandle& private_nh);
   void callback(velodyne_pointcloud::CloudNodeConfig& config, uint32_t level);
   velodyne_msgs::VelodyneSweepInfo create_sweep_entry(ros::Time stamp, float angle);
   void processScan(const velodyne_msgs::VelodyneScan::ConstPtr& scanMsg);
@@ -47,21 +51,32 @@ class Convert
 
   boost::shared_ptr<velodyne_rawdata::RawData> data_;
   ros::Subscriber velodyne_scan_;
-  ros::Publisher pointcloud_publisher_, deskew_info_publisher_;
+  ros::Publisher pointcloud_publisher_;
+  ros::Publisher cropped_pointcloud_publisher_;
+  ros::Publisher deskew_info_publisher_;
 
   // make the pointcloud container a member variable to append different slices
   velodyne_rawdata::VPointCloud accumulated_cloud_;
+  velodyne_rawdata::VPointCloud cropped_accumulated_cloud_;
   velodyne_msgs::VelodyneDeskewInfo deskew_info_;
   float prev_azimuth_;
+  bool synced_with_visibility_;
   ros::Time prev_stamp_;
+
   /// configuration parameters
   typedef struct
   {
     int npackets; ///< number of packets to combine
   } Config;
   Config config_;
-};
 
+  float visibility_angle_start_;
+  float visibility_angle_end_;
+
+  TimePoint start_full_sweep_;
+  TimePoint start_cropped_sweep_;
+  bool last_sample_added_;
+};
 } // namespace velodyne_pointcloud
 
 #endif // _VELODYNE_POINTCLOUD_CONVERT_H_


### PR DESCRIPTION
Publish a second pointcloud, `cropped_velodyne_points`, for each velodyne that only waits for points within in a set of "visibility angles" (the part of the circle that is not covered by our truck). This is to allow lower latency between when the first point is collected until the data is sent out.

```
            Full sweep PC,  cropped PC
Rate:        10hz,             10Hz
Delay:      ~100ms,        ~60ms
```

Reviewer, please take some time to check the math a bit.